### PR TITLE
Add linter tests to udp_bridge_interfaces

### DIFF
--- a/udp_bridge_interfaces/CMakeLists.txt
+++ b/udp_bridge_interfaces/CMakeLists.txt
@@ -35,6 +35,11 @@ rosidl_generate_interfaces(
 
 ament_export_dependencies(rosidl_default_runtime)
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()
 
 


### PR DESCRIPTION
## Summary

- Add `BUILD_TESTING` block with `ament_lint_auto_find_test_dependencies()` to `udp_bridge_interfaces/CMakeLists.txt`
- Test dependencies (`ament_lint_auto`, `ament_lint_common`) were already present in `package.xml`

## Test plan

- [x] Package builds successfully
- [x] `colcon test` runs linter tests (copyright, lint_cmake, xmllint)
- [ ] Pre-existing lint findings to be addressed in follow-up issues

Closes #5

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
