### PR TITLE
Add per-connection traffic diagnostics

### DIFF
--- a/udp_bridge/CMakeLists.txt
+++ b/udp_bridge/CMakeLists.txt
@@ -8,6 +8,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
@@ -42,6 +43,7 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC
     rclcpp::rclcpp
     rclcpp_lifecycle::rclcpp_lifecycle
+    ${diagnostic_updater_TARGETS}
     ${udp_bridge_interfaces_TARGETS}
     ${ZLIB_LIBRARIES}
 )

--- a/udp_bridge/include/udp_bridge/connection.h
+++ b/udp_bridge/include/udp_bridge/connection.h
@@ -80,6 +80,9 @@ public:
   /// Returns the average data rate.
   udp_bridge_interfaces::msg::DataRates data_sent_rate(rclcpp::Time time, PacketSendCategory category);
 
+  /// Returns the average data rate across all packet categories.
+  udp_bridge_interfaces::msg::DataRates data_sent_rate(rclcpp::Time time);
+
   /// Remove saved sent packets older than cutoff_time.
   void cleanup_sent_packets(rclcpp::Time cutoff_time);
 

--- a/udp_bridge/include/udp_bridge/udp_bridge.h
+++ b/udp_bridge/include/udp_bridge/udp_bridge.h
@@ -4,6 +4,9 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp/generic_publisher.hpp"
 #include "rclcpp/generic_subscription.hpp"
+#include "diagnostic_updater/diagnostic_updater.hpp"
+
+#include <set>
 
 #include "udp_bridge_interfaces/srv/subscribe.hpp"
 #include "udp_bridge_interfaces/srv/add_remote.hpp"
@@ -155,6 +158,18 @@ private:
   /// Timer callback where data rate stats are reported
   void statsReportCallback();
 
+  /// Periodic tick: sync per-connection diagnostic tasks with current remotes
+  /// and force the diagnostic_updater to publish.
+  void diagnosticTick();
+
+  /// Register a diagnostic task for any (remote, connection) pair not yet tracked.
+  void syncDiagnosticTasks();
+
+  /// Populate a diagnostic status message for one (remote, connection) pair.
+  void diagnoseConnection(const std::string& remote_name,
+                          const std::string& connection_id,
+                          diagnostic_updater::DiagnosticStatusWrapper& stat);
+
   /// Timer callback where info on available topics are periodically reported
   void bridgeInfoCallback();
 
@@ -217,6 +232,12 @@ private:
   rclcpp::TimerBase::SharedPtr bridge_info_timer_;
   rclcpp::TimerBase::SharedPtr spin_timer_;
   rclcpp::TimerBase::SharedPtr subscription_update_timer_;
+  rclcpp::TimerBase::SharedPtr diagnostic_timer_;
+
+  std::unique_ptr<diagnostic_updater::Updater> diagnostic_updater_;
+  /// Names of diagnostic tasks already registered, so we don't double-add as
+  /// remotes/connections appear.
+  std::set<std::string> diagnostic_task_names_;
 
   uint64_t next_packet_number_ = 0;
   rclcpp::Time last_packet_number_assign_time_;

--- a/udp_bridge/package.xml
+++ b/udp_bridge/package.xml
@@ -9,6 +9,7 @@
   <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>diagnostic_updater</depend>
   <depend>lifecycle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/udp_bridge/src/connection.cpp
+++ b/udp_bridge/src/connection.cpp
@@ -297,6 +297,12 @@ DataRates Connection::data_sent_rate(rclcpp::Time time, PacketSendCategory categ
   return sent_packet_statistics_.get(category);
 }
 
+DataRates Connection::data_sent_rate(rclcpp::Time time)
+{
+  (void)time;
+  return sent_packet_statistics_.get();
+}
+
 
 void Connection::resend_packets(const std::vector<uint64_t> &missing_packets, int socket, rclcpp::Time now)
 {

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -187,6 +187,11 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
   spin_timer_ = create_wall_timer(10ms, std::bind(&UDPBridge::spin_once, this));
   subscription_update_timer_ = create_wall_timer(1s, std::bind(&UDPBridge::updateLocalSubscriptions, this));
 
+  diagnostic_updater_ = std::make_unique<diagnostic_updater::Updater>(this);
+  diagnostic_updater_->setHardwareID(name_);
+  syncDiagnosticTasks();
+  diagnostic_timer_ = create_wall_timer(1s, std::bind(&UDPBridge::diagnosticTick, this));
+
   return LifecycleNode::on_configure(state);
 }
 
@@ -1030,6 +1035,102 @@ UDPBridge::RemoteConnectionsList UDPBridge::allRemotes() const
     if(remote.second)
       ret[remote.first];
   return ret;
+}
+
+void UDPBridge::diagnosticTick()
+{
+  if(!diagnostic_updater_)
+    return;
+  syncDiagnosticTasks();
+  diagnostic_updater_->force_update();
+}
+
+void UDPBridge::syncDiagnosticTasks()
+{
+  if(!diagnostic_updater_)
+    return;
+  for(auto& remote_entry: remote_nodes_)
+  {
+    const std::string& remote_name = remote_entry.first;
+    if(!remote_entry.second)
+      continue;
+    for(auto& connection: remote_entry.second->connections())
+    {
+      if(!connection)
+        continue;
+      std::string connection_id = connection->id();
+      std::string task_name = "udp_bridge " + name_ + ": " + remote_name + ": " + connection_id;
+      if(diagnostic_task_names_.count(task_name))
+        continue;
+      diagnostic_updater_->add(task_name,
+        [this, remote_name, connection_id](diagnostic_updater::DiagnosticStatusWrapper& stat)
+        {
+          diagnoseConnection(remote_name, connection_id, stat);
+        });
+      diagnostic_task_names_.insert(task_name);
+    }
+  }
+}
+
+void UDPBridge::diagnoseConnection(const std::string& remote_name,
+                                   const std::string& connection_id,
+                                   diagnostic_updater::DiagnosticStatusWrapper& stat)
+{
+  auto remote_it = remote_nodes_.find(remote_name);
+  if(remote_it == remote_nodes_.end() || !remote_it->second)
+  {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "remote not registered");
+    return;
+  }
+  auto connection = remote_it->second->connection(connection_id);
+  if(!connection)
+  {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "connection not registered");
+    return;
+  }
+
+  auto now_time = now();
+  auto totals = connection->data_sent_rate(now_time);
+  auto resends = connection->data_sent_rate(now_time, PacketSendCategory::resend);
+  auto rx = connection->data_receive_rate(now_time.seconds());
+  double last_rx = connection->last_receive_time();
+  double rx_age = (last_rx > 0.0) ? (now_time.seconds() - last_rx) : -1.0;
+
+  stat.add("host", connection->host());
+  stat.add("port", static_cast<int>(connection->port()));
+  stat.add("rate_limit_bytes_per_sec", static_cast<unsigned int>(connection->rateLimit()));
+  stat.add("tx_ok_bytes_per_sec", totals.success_bytes_per_second);
+  stat.add("tx_failed_bytes_per_sec", totals.failed_bytes_per_second);
+  stat.add("tx_dropped_bytes_per_sec", totals.dropped_bytes_per_second);
+  stat.add("tx_resend_bytes_per_sec", resends.success_bytes_per_second);
+  stat.add("rx_bytes_per_sec", rx.first);
+  stat.add("rx_duplicate_bytes_per_sec", rx.second);
+  stat.add("last_rx_age_s", rx_age);
+
+  constexpr double kStaleWarnSeconds = 5.0;
+  constexpr double kStaleErrorSeconds = 10.0;
+
+  std::string summary = "tx " + std::to_string(static_cast<uint64_t>(totals.success_bytes_per_second))
+                      + " B/s, rx " + std::to_string(static_cast<uint64_t>(rx.first)) + " B/s";
+
+  if(last_rx > 0.0 && rx_age > kStaleErrorSeconds)
+  {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+                 "no rx for " + std::to_string(static_cast<uint64_t>(rx_age)) + "s");
+  }
+  else if(totals.failed_bytes_per_second > 0 || totals.dropped_bytes_per_second > 0)
+  {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "tx failures/drops");
+  }
+  else if(last_rx > 0.0 && rx_age > kStaleWarnSeconds)
+  {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN,
+                 "no rx for " + std::to_string(static_cast<uint64_t>(rx_age)) + "s");
+  }
+  else
+  {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, summary);
+  }
 }
 
 // void UDPBridge::maximumPacketSizeCallback(const std_msgs::Int32::ConstPtr& msg)

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -1041,6 +1041,8 @@ void UDPBridge::diagnosticTick()
 {
   if(!diagnostic_updater_)
     return;
+  if(get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+    return;
   syncDiagnosticTasks();
   diagnostic_updater_->force_update();
 }

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -207,6 +207,9 @@ UDPBridge::CallbackReturn UDPBridge::on_deactivate(const rclcpp_lifecycle::State
 
 UDPBridge::CallbackReturn UDPBridge::on_cleanup(const rclcpp_lifecycle::State & state)
 {
+  diagnostic_timer_.reset();
+  diagnostic_updater_.reset();
+  diagnostic_task_names_.clear();
   return LifecycleNode::on_cleanup(state);
 }
 


### PR DESCRIPTION
## Summary

- Adds `diagnostic_updater` to udp_bridge publishing per-(remote, connection) `DiagnosticStatus` at 1 Hz
- Reports tx ok/failed/dropped, resend, rx, duplicate bytes/sec, and last rx age
- Levels: OK, WARN (failures/drops or >5s silence), ERROR (>10s silence), STALE (connection gone)
- Task names include bridge `name` parameter for multi-instance disambiguation
- New `Connection::data_sent_rate(time)` overload returning totals across all categories

Closes #7

## Test plan

- [ ] Build with `colcon build --packages-select udp_bridge`
- [ ] Run with two remotes, verify `/diagnostics` shows per-connection entries
- [ ] Confirm WARN level triggers on rx silence >5s
- [ ] Confirm ERROR level triggers on rx silence >10s

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
