### PR TITLE
'Giving up on resend' WARN log too loud — rate-limit or surface as DiagnosticStatus

### DIFF
--- a/.agent/work-plans/issue-22/plan.md
+++ b/.agent/work-plans/issue-22/plan.md
@@ -16,9 +16,9 @@ This is also a worked instance of the workspace pattern documented in memory `fe
 
 1. **Demote per-event WARN to DEBUG** at `remote_node.cpp:329-334`. One-line change (`RCLCPP_WARN_STREAM` → `RCLCPP_DEBUG_STREAM`). Per-event detail stays available in bags for forensic analysis; live operator log panels stay clean. Independently testable — restores quiet logs even if step 2 spills.
 
-2. **Add per-remote diagnostic task** that publishes give-up rate + cumulative count + threshold-based level. Hook into the existing `diagnostic_updater_` at the per-`RemoteNode` level (parallel to existing per-connection tasks in `udp_bridge.cpp:1495-1507`). New helper `UDPBridge::diagnoseRemoteGiveups(remote_name, stat)` mirrors `diagnoseConnection`'s shape. State needed: a `last_published_count_` and `last_publish_time_` per remote, reset-safe (if `current < last`, publish rate=0 — handles counter reset per observation in [#21](https://github.com/rolker/udp_bridge/issues/21)).
+2. **Add per-remote diagnostic task** that publishes give-up rate + cumulative count + threshold-based level. Hook into the existing `diagnostic_updater_` at the per-`RemoteNode` level (parallel to existing per-connection tasks in `udp_bridge.cpp:1495-1507`). New helper `UDPBridge::diagnoseRemoteGiveups(remote_name, stat)` mirrors `diagnoseConnection`'s shape. Diagnostic task name follows the existing convention: `"udp_bridge " + name_ + ": " + remote_name + ": resend give-ups"` (mirrors the per-connection format at `udp_bridge.cpp:1498`). State needed: a `last_published_count_` and `last_publish_time_` per remote, reset-safe (if `current < last`, publish rate=0 — handles counter reset per observation in [#21](https://github.com/rolker/udp_bridge/issues/21)).
 
-3. **Declare thresholds as ROS 2 parameters**, not `const`. Defaults: `resend_giveup_warn_rate_per_s=5.0`, `resend_giveup_error_rate_per_s=50.0` (calibrated against the 2026-05-19 storm at ~700/s peak / ~3.9/s average — both would have correctly fired ERROR at 50/s). Allows field tuning via YAML without rebuild.
+3. **Declare thresholds as ROS 2 parameters**, not `const`. Defaults: `resend_giveup_warn_rate_per_s=5.0`, `resend_giveup_error_rate_per_s=50.0` — confirmed with owner. Calibrated against the 2026-05-19 storm (~700/s peak / ~3.9/s average steady): the average correctly fires WARN, the burst correctly fires ERROR. Lower-WARN-threshold question (Open Question 2 below) deferred — start with 5/50 and revisit if operators report missing mild-loss signal. Parameters allow field tuning via YAML without rebuild.
 
 4. **Tests** — extend `test/test_remote_node_resend.cpp` is *not* the right home for the publisher tests (RemoteNode doesn't know about the diagnostic infrastructure — only exposes `resendGiveupCount()`). Add a new `test/test_remote_giveup_diagnostic.cpp` exercising the rate-calculation logic in isolation (counter-reset case, threshold transitions OK↔WARN↔ERROR, zero-rate steady state, multi-remote independence).
 
@@ -62,11 +62,14 @@ This is also a worked instance of the workspace pattern documented in memory `fe
 
 ## Open Questions
 
-1. **Annunciator filter behavior**: does the operator-side annunciator allowlist diagnostic task names, or does it accept any `udp_bridge: *` pattern? If allowlisted, this PR needs a paired follow-up commit on `unh_echoboats_project11`. Spot-check before opening this for review.
+1. **Annunciator filter behavior**: does the operator-side annunciator allowlist diagnostic task names, or does it accept any `udp_bridge: *` pattern? If allowlisted, this PR needs a paired follow-up commit on `unh_echoboats_project11`. Owner deferred — spot-check during implementation by reading the annunciator's diagnostic-subscription config; if allowlisted, file a paired follow-up issue rather than block this PR.
 
-2. **Threshold defaults**: starting suggestion is 5/s WARN, 50/s ERROR. Field data point (2026-05-19): ~3.9/s average steady storm, ~700/s burst. The averages would have shown WARN, not ERROR — is that the operator-desired indication, or should the WARN threshold be lower (e.g., 1/s) to flag even mild loss? Surfacing for owner input.
+2. **Threshold lower-WARN question** (deferred): owner accepted 5/50 starting defaults. The deferred question is whether the WARN threshold should be lowered (e.g., to 1/s) in a future tuning pass to flag mild loss earlier. Not blocking this PR — surface as a follow-up if operators report missing-signal in the field.
 
-3. **Per-remote vs. aggregate diagnostic name**: owner's comment proposed `"udp_bridge: resend give-ups for '<remote_name>'"`. Confirming this matches the existing naming convention in `udp_bridge.cpp:1498` (`"udp_bridge " + name_ + ": " + remote_name + ": " + connection_id`). Slight format inconsistency — should the new task use `"udp_bridge " + name_ + ": " + remote_name + ": resend give-ups"` for uniformity? Recommend yes; will confirm before coding.
+## Decided (during planning, after owner input 2026-05-20)
+
+- **Thresholds**: 5/s WARN, 50/s ERROR (starting defaults; parameter-tunable per Approach step 3).
+- **Diagnostic task naming**: use the existing convention from `udp_bridge.cpp:1498` — `"udp_bridge " + name_ + ": " + remote_name + ": resend give-ups"`.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-22/plan.md
+++ b/.agent/work-plans/issue-22/plan.md
@@ -1,0 +1,73 @@
+# Plan: 'Giving up on resend' WARN log too loud — rate-limit or surface as DiagnosticStatus
+
+## Issue
+
+https://github.com/rolker/udp_bridge/issues/22
+
+## Context
+
+After [#13](https://github.com/rolker/udp_bridge/pull/13) added resend give-up tracking, the per-event WARN at `remote_node.cpp:329` fires at **~233/min average, hundreds-to-thousands/s burst** on any lossy link (verified against the 2026-05-19 BizzyBoat deployment: 27,992 WARN entries in ~2h). This pollutes `/rosout`, bloats bags by ~5.6 MB per deployment, and desensitizes operators to genuine WARNs. The give-up *behavior* is correct; the *severity* is the problem.
+
+Issue owner's comment lays out the convergent design: demote the per-event log WARN → DEBUG, and publish a per-remote `DiagnosticStatus` with rate metric and threshold-based severity. Code exploration adds a refinement: udp_bridge already runs a `diagnostic_updater::Updater` (added at `udp_bridge.cpp:341`) and registers per-(remote, connection) diagnostic tasks. The new resend-give-up status should integrate with that existing infrastructure rather than introduce a parallel raw publisher.
+
+This is also a worked instance of the workspace pattern documented in memory `feedback_wifi_disconnect_not_an_error` — link-conditions events belong in DiagnosticStatus, not WARN logs.
+
+## Approach
+
+1. **Demote per-event WARN to DEBUG** at `remote_node.cpp:329-334`. One-line change (`RCLCPP_WARN_STREAM` → `RCLCPP_DEBUG_STREAM`). Per-event detail stays available in bags for forensic analysis; live operator log panels stay clean. Independently testable — restores quiet logs even if step 2 spills.
+
+2. **Add per-remote diagnostic task** that publishes give-up rate + cumulative count + threshold-based level. Hook into the existing `diagnostic_updater_` at the per-`RemoteNode` level (parallel to existing per-connection tasks in `udp_bridge.cpp:1495-1507`). New helper `UDPBridge::diagnoseRemoteGiveups(remote_name, stat)` mirrors `diagnoseConnection`'s shape. State needed: a `last_published_count_` and `last_publish_time_` per remote, reset-safe (if `current < last`, publish rate=0 — handles counter reset per observation in [#21](https://github.com/rolker/udp_bridge/issues/21)).
+
+3. **Declare thresholds as ROS 2 parameters**, not `const`. Defaults: `resend_giveup_warn_rate_per_s=5.0`, `resend_giveup_error_rate_per_s=50.0` (calibrated against the 2026-05-19 storm at ~700/s peak / ~3.9/s average — both would have correctly fired ERROR at 50/s). Allows field tuning via YAML without rebuild.
+
+4. **Tests** — extend `test/test_remote_node_resend.cpp` is *not* the right home for the publisher tests (RemoteNode doesn't know about the diagnostic infrastructure — only exposes `resendGiveupCount()`). Add a new `test/test_remote_giveup_diagnostic.cpp` exercising the rate-calculation logic in isolation (counter-reset case, threshold transitions OK↔WARN↔ERROR, zero-rate steady state, multi-remote independence).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `udp_bridge/src/remote_node.cpp:329-334` | `RCLCPP_WARN_STREAM` → `RCLCPP_DEBUG_STREAM` (1-line severity change; message text unchanged) |
+| `udp_bridge/src/udp_bridge.cpp` | Declare 2 new parameters (`resend_giveup_warn_rate_per_s`, `resend_giveup_error_rate_per_s`); register per-remote diagnostic task in the same loop as existing per-connection tasks (~1500); implement `diagnoseRemoteGiveups()` (~50 LOC) |
+| `udp_bridge/include/udp_bridge/udp_bridge.h` | Declare `diagnoseRemoteGiveups()`; add `last_giveup_publish_time_` / `last_giveup_count_` per-remote maps; declare parameter members |
+| `udp_bridge/test/test_remote_giveup_diagnostic.cpp` | **NEW** — gtest covering rate calculation, counter reset, threshold transitions, multi-remote independence |
+| `udp_bridge/CMakeLists.txt` | Register the new test executable |
+| `udp_bridge/README.md` | Add a "Diagnostic surface" section (or extend existing) documenting the new `resend give-ups for '<remote>'` diagnostic name + threshold parameters |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | DiagnosticStatus is *more* informative than per-event WARN spam — a single aggregator indicator with rate metric beats 200/min of noise. Operators get a tunable surface (params), not a hard-coded behavior. |
+| A change includes its consequences | Test coverage added in step 4; README updated; existing `test_remote_node_resend.cpp` continues to verify counter correctness unchanged. |
+| Only what's needed | Reuses existing `diagnostic_updater_` infrastructure + existing `resendGiveupCount()` accessor + existing `Remote.msg.resend_giveup_count` field. No new accounting state introduced. ~50 LOC plus tests. |
+| Test what breaks | Test scope matches the field-observed failure modes: counter reset across `udp_bridge` restart (per #21), threshold boundaries calibrated against the 2026-05-19 storm, multi-remote independence (storm hit both directions). |
+| Improve incrementally | Two atomic commits: step 1 (one-line WARN→DEBUG) is independently mergeable; step 2 (diagnostic publisher + parameters + tests + README) is its own commit. |
+| Workspace vs. project separation | Pure project change in `udp_bridge`. No workspace coupling. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| [0008 — Follow ROS 2 Official Conventions](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0008-follow-ros2-official-conventions.md) | Yes | Use `diagnostic_updater::Updater` (already present in this package), not a raw `DiagnosticStatus` publisher — the higher-level API is the standard ROS 2 convention and integrates cleanly with `diagnostic_aggregator`. New parameters declared via `declare_parameter()` per ROS 2 convention. |
+| [0001 — Adopt ADRs](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0001-adopt-architecture-decision-records.md) | Watch | Single-package severity/diagnostic change — no ADR needed in this repo. The broader workspace pattern ("link-conditions events go through DiagnosticStatus") may deserve an ADR if it cascades to other packages; flag as a follow-up question rather than block. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Demote a public-facing WARN | Bag-replay workflows that grep for "Giving up on resend" in `/rosout` | Yes — README will note the demotion and the new diagnostic surface |
+| Add new diagnostic task name | Operator-side annunciator (`unh_echoboats_project11`'s `bizzyboat_operator_annunciator`) — if it uses an allowlist, the new name has to be added | **Open question** — annunciator's filter behavior should be checked before merge |
+| Add new ROS 2 parameters | Deployment YAMLs that override udp_bridge parameters (BizzyBoat / IzzyBoat launch configs) | No, defaults are sensible; per-deployment override is optional |
+| Add new test file | `CMakeLists.txt` test registration | Yes — explicit in Files to Change |
+
+## Open Questions
+
+1. **Annunciator filter behavior**: does the operator-side annunciator allowlist diagnostic task names, or does it accept any `udp_bridge: *` pattern? If allowlisted, this PR needs a paired follow-up commit on `unh_echoboats_project11`. Spot-check before opening this for review.
+
+2. **Threshold defaults**: starting suggestion is 5/s WARN, 50/s ERROR. Field data point (2026-05-19): ~3.9/s average steady storm, ~700/s burst. The averages would have shown WARN, not ERROR — is that the operator-desired indication, or should the WARN threshold be lower (e.g., 1/s) to flag even mild loss? Surfacing for owner input.
+
+3. **Per-remote vs. aggregate diagnostic name**: owner's comment proposed `"udp_bridge: resend give-ups for '<remote_name>'"`. Confirming this matches the existing naming convention in `udp_bridge.cpp:1498` (`"udp_bridge " + name_ + ": " + remote_name + ": " + connection_id`). Slight format inconsistency — should the new task use `"udp_bridge " + name_ + ": " + remote_name + ": resend give-ups"` for uniformity? Recommend yes; will confirm before coding.
+
+## Estimated Scope
+
+Single PR, two atomic commits. Estimated diff: ~80 LOC implementation + ~150 LOC tests + ~20 LOC README. No cross-repo coordination required other than the annunciator allowlist check (Open Question 1).

--- a/.agent/work-plans/issue-22/plan.md
+++ b/.agent/work-plans/issue-22/plan.md
@@ -20,7 +20,7 @@ This is also a worked instance of the workspace pattern documented in memory `fe
 
 3. **Declare thresholds as ROS 2 parameters**, not `const`. Defaults: `resend_giveup_warn_rate_per_s=5.0`, `resend_giveup_error_rate_per_s=50.0` — confirmed with owner. Calibrated against the 2026-05-19 storm (~700/s peak / ~3.9/s average steady): the average correctly fires WARN, the burst correctly fires ERROR. Lower-WARN-threshold question (Open Question 2 below) deferred — start with 5/50 and revisit if operators report missing mild-loss signal. Parameters allow field tuning via YAML without rebuild.
 
-4. **Tests** — extend `test/test_remote_node_resend.cpp` is *not* the right home for the publisher tests (RemoteNode doesn't know about the diagnostic infrastructure — only exposes `resendGiveupCount()`). Add a new `test/test_remote_giveup_diagnostic.cpp` exercising the rate-calculation logic in isolation (counter-reset case, threshold transitions OK↔WARN↔ERROR, zero-rate steady state, multi-remote independence).
+4. **Tests** — extend `test/test_remote_node_resend.cpp` is *not* the right home for the publisher tests (RemoteNode doesn't know about the diagnostic infrastructure — only exposes `resendGiveupCount()`). Add a new `test/test_remote_giveup_diagnostic.cpp` exercising the rate-calculation logic in isolation (counter-reset case, threshold transitions OK↔WARN↔ERROR, zero-rate steady state, multi-remote independence). Uses the same simulated-clock pattern as `test_remote_node_resend.cpp` to keep timing deterministic — the rate calculation is time-dependent, so test fixtures must control `now()` rather than rely on wall-clock.
 
 ## Files to Change
 
@@ -42,6 +42,7 @@ This is also a worked instance of the workspace pattern documented in memory `fe
 | Only what's needed | Reuses existing `diagnostic_updater_` infrastructure + existing `resendGiveupCount()` accessor + existing `Remote.msg.resend_giveup_count` field. No new accounting state introduced. ~50 LOC plus tests. |
 | Test what breaks | Test scope matches the field-observed failure modes: counter reset across `udp_bridge` restart (per #21), threshold boundaries calibrated against the 2026-05-19 storm, multi-remote independence (storm hit both directions). |
 | Improve incrementally | Two atomic commits: step 1 (one-line WARN→DEBUG) is independently mergeable; step 2 (diagnostic publisher + parameters + tests + README) is its own commit. |
+| Enforcement over documentation | The "link-conditions events go through DiagnosticStatus, not WARN" rule that this plan applies is a workspace convention (memory `feedback_wifi_disconnect_not_an_error`), not enforcement. Applying the convention here is the right step; broader enforcement (a grep / lint that flags `RCLCPP_WARN` near `resend_giveup_count_` and similar patterns) is acknowledged as out of scope for this PR. |
 | Workspace vs. project separation | Pure project change in `udp_bridge`. No workspace coupling. |
 
 ## ADR Compliance

--- a/.agent/work-plans/issue-22/plan.md
+++ b/.agent/work-plans/issue-22/plan.md
@@ -16,20 +16,53 @@ This is also a worked instance of the workspace pattern documented in memory `fe
 
 1. **Demote per-event WARN to DEBUG** at `remote_node.cpp:329-334`. One-line change (`RCLCPP_WARN_STREAM` → `RCLCPP_DEBUG_STREAM`). Per-event detail stays available in bags for forensic analysis; live operator log panels stay clean. Independently testable — restores quiet logs even if step 2 spills.
 
-2. **Add per-remote diagnostic task** that publishes give-up rate + cumulative count + threshold-based level. Hook into the existing `diagnostic_updater_` at the per-`RemoteNode` level (parallel to existing per-connection tasks in `udp_bridge.cpp:1495-1507`). New helper `UDPBridge::diagnoseRemoteGiveups(remote_name, stat)` mirrors `diagnoseConnection`'s shape. Diagnostic task name follows the existing convention: `"udp_bridge " + name_ + ": " + remote_name + ": resend give-ups"` (mirrors the per-connection format at `udp_bridge.cpp:1498`). State needed: a `last_published_count_` and `last_publish_time_` per remote, reset-safe (if `current < last`, publish rate=0 — handles counter reset per observation in [#21](https://github.com/rolker/udp_bridge/issues/21)).
+2. **Add per-remote diagnostic task** that publishes give-up rate + cumulative count + threshold-based level. Hook into the existing `diagnostic_updater_` at the per-`RemoteNode` level (parallel to existing per-connection tasks in `udp_bridge.cpp:1495-1507`). New helper `UDPBridge::diagnoseRemoteGiveups(remote_name, stat)` mirrors `diagnoseConnection`'s shape. Diagnostic task name follows the existing convention: `"udp_bridge " + name_ + ": " + remote_name + ": resend give-ups"` (mirrors the per-connection format at `udp_bridge.cpp:1498` — this is a deliberate divergence from the owner's comment wording, which proposed `"udp_bridge: resend give-ups for '<remote>'"`; the convention-conforming form is preferred for consistency with the existing aggregator output).
+
+   **State**: `last_giveup_count_` and `last_giveup_publish_time_` per-remote maps live on `UDPBridge` and are guarded by the **existing `remote_nodes_mutex_`** (extended scope — short reads inside the diagnostic callback, no new lock introduced). Reset-safe: if `current_count < last_count`, publish rate=0 (handles counter reset per [#21](https://github.com/rolker/udp_bridge/issues/21) observation).
+
+   **Lifecycle**: cleared in `on_cleanup` alongside the existing `diagnostic_task_names_` clear at `udp_bridge.cpp:364`. `diagnostic_updater::Updater` has no per-task `remove()` API, so re-registration of the same task name after activate→deactivate→activate must be guarded the same way `diagnostic_task_names_` already gates re-adds (line 1499). The diagnostic callback's "remote not registered" branch mirrors `diagnoseConnection`'s `STALE` return (line 1520).
 
 3. **Declare thresholds as ROS 2 parameters**, not `const`. Defaults: `resend_giveup_warn_rate_per_s=5.0`, `resend_giveup_error_rate_per_s=50.0` — confirmed with owner. Calibrated against the 2026-05-19 storm (~700/s peak / ~3.9/s average steady): the average correctly fires WARN, the burst correctly fires ERROR. Lower-WARN-threshold question (Open Question 2 below) deferred — start with 5/50 and revisit if operators report missing mild-loss signal. Parameters allow field tuning via YAML without rebuild.
 
-4. **Tests** — extend `test/test_remote_node_resend.cpp` is *not* the right home for the publisher tests (RemoteNode doesn't know about the diagnostic infrastructure — only exposes `resendGiveupCount()`). Add a new `test/test_remote_giveup_diagnostic.cpp` exercising the rate-calculation logic in isolation (counter-reset case, threshold transitions OK↔WARN↔ERROR, zero-rate steady state, multi-remote independence). Uses the same simulated-clock pattern as `test_remote_node_resend.cpp` to keep timing deterministic — the rate calculation is time-dependent, so test fixtures must control `now()` rather than rely on wall-clock.
+4. **Tests** — extend `test/test_remote_node_resend.cpp` is *not* the right home for the publisher tests (RemoteNode doesn't know about the diagnostic infrastructure — only exposes `resendGiveupCount()`).
+
+   **Test strategy**: extract the rate/threshold logic into a **static free function** so it can be tested without bringing up a `UDPBridge` instance. Proposed signature:
+
+   ```cpp
+   struct GiveupDiagnostic {
+     uint8_t level;        // diagnostic_msgs::DiagnosticStatus OK/WARN/ERROR
+     double rate_per_s;
+     uint32_t total;
+   };
+
+   GiveupDiagnostic computeGiveupDiagnostic(
+       uint32_t prev_count,
+       uint32_t current_count,
+       double elapsed_s,
+       double warn_thresh,
+       double error_thresh);
+   ```
+
+   The free function lives in a small new header (`udp_bridge/include/udp_bridge/giveup_diagnostic.h`) and is consumed by `UDPBridge::diagnoseRemoteGiveups()` as a thin wrapper. Test file `test/test_giveup_diagnostic.cpp` exercises:
+
+   - Steady-state rate calculation
+   - Counter reset (`current < prev` → rate=0, level=OK)
+   - Threshold transitions OK↔WARN↔ERROR at the configured cutoffs
+   - **First-call behavior** (no prior call → caller passes `prev_count=0` and the function must return rate=0 without dividing by `elapsed_s=0`)
+   - **Zero-elapsed-time edge case** (`elapsed_s == 0` → must not divide by zero; return rate=0)
+   - Multi-remote independence is covered by the wrapper-side state isolation (separate map entries), not by this helper — verified at integration level via a follow-up sanity-check rather than a dedicated unit test.
+
+   Determinism: the free function takes `elapsed_s` as a parameter, so the test doesn't need a clock at all — the time-dependence is moved out of the test fixture and into the caller. The wrapper `diagnoseRemoteGiveups()` uses `this->now()` (controllable via `use_sim_time` if a future integration test wants it).
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
 | `udp_bridge/src/remote_node.cpp:329-334` | `RCLCPP_WARN_STREAM` → `RCLCPP_DEBUG_STREAM` (1-line severity change; message text unchanged) |
-| `udp_bridge/src/udp_bridge.cpp` | Declare 2 new parameters (`resend_giveup_warn_rate_per_s`, `resend_giveup_error_rate_per_s`); register per-remote diagnostic task in the same loop as existing per-connection tasks (~1500); implement `diagnoseRemoteGiveups()` (~50 LOC) |
-| `udp_bridge/include/udp_bridge/udp_bridge.h` | Declare `diagnoseRemoteGiveups()`; add `last_giveup_publish_time_` / `last_giveup_count_` per-remote maps; declare parameter members |
-| `udp_bridge/test/test_remote_giveup_diagnostic.cpp` | **NEW** — gtest covering rate calculation, counter reset, threshold transitions, multi-remote independence |
+| `udp_bridge/src/udp_bridge.cpp` | Declare 2 new parameters (`resend_giveup_warn_rate_per_s`, `resend_giveup_error_rate_per_s`); register per-remote diagnostic task in the same loop as existing per-connection tasks (~1500); implement `diagnoseRemoteGiveups()` (~30 LOC — most logic moves to the free function); clear new maps in `on_cleanup` alongside existing `diagnostic_task_names_` reset (~364) |
+| `udp_bridge/include/udp_bridge/udp_bridge.h` | Declare `diagnoseRemoteGiveups()`; add `last_giveup_count_` / `last_giveup_publish_time_` per-remote maps guarded by `remote_nodes_mutex_`; declare parameter members |
+| `udp_bridge/include/udp_bridge/giveup_diagnostic.h` | **NEW** — header for `computeGiveupDiagnostic()` free function (~25 LOC including the `GiveupDiagnostic` struct) |
+| `udp_bridge/test/test_giveup_diagnostic.cpp` | **NEW** — gtest covering steady-state rate, counter reset, threshold transitions, first-call (`prev_count=0`), zero-elapsed-time edge case |
 | `udp_bridge/CMakeLists.txt` | Register the new test executable |
 | `udp_bridge/README.md` | Add a "Diagnostic surface" section (or extend existing) documenting the new `resend give-ups for '<remote>'` diagnostic name + threshold parameters |
 
@@ -71,7 +104,9 @@ This is also a worked instance of the workspace pattern documented in memory `fe
 
 - **Thresholds**: 5/s WARN, 50/s ERROR (starting defaults; parameter-tunable per Approach step 3).
 - **Diagnostic task naming**: use the existing convention from `udp_bridge.cpp:1498` — `"udp_bridge " + name_ + ": " + remote_name + ": resend give-ups"`.
+- **Mutex strategy**: extend `remote_nodes_mutex_` scope to cover the new per-remote diag maps (no new mutex introduced).
+- **Test fixture approach**: extract rate calc into a `computeGiveupDiagnostic()` static free function in `udp_bridge/include/udp_bridge/giveup_diagnostic.h`; test the helper directly (no `UDPBridge` instance, no clock fixture needed).
 
 ## Estimated Scope
 
-Single PR, two atomic commits. Estimated diff: ~80 LOC implementation + ~150 LOC tests + ~20 LOC README. No cross-repo coordination required other than the annunciator allowlist check (Open Question 1).
+Single PR, two atomic commits. Estimated diff: ~80 LOC implementation (split: ~30 LOC `UDPBridge::diagnoseRemoteGiveups()` wrapper + ~25 LOC `giveup_diagnostic.h` free function + ~25 LOC parameter / map / cleanup wiring) + ~150 LOC tests + ~20 LOC README. No cross-repo coordination required other than the annunciator allowlist check (Open Question 1).

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -16,9 +16,9 @@ issue: 22
 **Must-fix**: 1 | **Suggestions**: 2
 
 ### Findings
-- [ ] (must-fix, Claude Adv. + Copilot Adv. cross-source) Thresholds latched at `on_configure`, README implies runtime-tunable. Add `OnSetParametersCallback` OR tighten README wording — `udp_bridge.cpp:144-147`, `README.md:31`
-- [ ] (suggestion, Claude Adv.) `std::to_string(double)` in summary text emits 6 fractional digits — noisy in aggregator UIs. Use `std::fixed << std::setprecision(2)` — `udp_bridge.cpp:1667-1671`
-- [ ] (suggestion, Copilot Adv.) No wrapper-side integration test for `diagnoseRemoteGiveups` (mutex discipline, map-update ordering, STALE path). Plan §4 deferred this as "verified at integration level"; flagging the coverage cost — `test/test_giveup_diagnostic.cpp` (gap)
+- [x] (must-fix, Claude Adv. + Copilot Adv. cross-source) Thresholds latched at `on_configure`, README implies runtime-tunable. Resolved by adding `OnSetParametersCallback` — `udp_bridge.cpp` `on_configure` registers the handle, validates non-negative thresholds, applies under `remote_nodes_mutex_` (matches reader's lock). `on_cleanup` resets the handle. Reader now samples thresholds inside the lock too.
+- [x] (suggestion, Claude Adv.) `std::to_string(double)` in summary text replaced with `std::ostringstream` + `std::fixed << std::setprecision(2)`. Structured KeyValues (raw doubles) unaffected.
+- [x] (suggestion, Copilot Adv.) Wrapper-side test coverage gap closed by refactor: consolidated two parallel maps into `std::map<std::string, GiveupRateState>` + extracted `stepGiveupDiagnostic` helper into `giveup_diagnostic.h`. Six new tests cover first-call init, two-call sequence (map-update ordering), counter reset across calls, zero-elapsed between steps, multi-state independence, and threshold-change-takes-effect-on-next-step.
 
 ### Notes
 - Cross-source convergence on must-fix #1: both Claude Adv. (in-context sub-agent) and Copilot Adv. (CLI) independently flagged the parameter live-update gap. Strongest signal class per ADR-0013.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -1,0 +1,28 @@
+---
+issue: 22
+---
+
+# Issue #22 — 'Giving up on resend' WARN log too loud — rate-limit or surface as DiagnosticStatus
+
+## Local Review
+**Status**: complete
+**When**: 2026-05-20 14:10 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: changes-requested
+
+**PR**: #24 at `cfd57d3`
+**Mode**: post-PR
+**Depth**: Standard (reason: new C++ surface + new ROS 2 params + new threaded state on `UDPBridge`; 8 files +506/-4)
+**Must-fix**: 1 | **Suggestions**: 2
+
+### Findings
+- [ ] (must-fix, Claude Adv. + Copilot Adv. cross-source) Thresholds latched at `on_configure`, README implies runtime-tunable. Add `OnSetParametersCallback` OR tighten README wording — `udp_bridge.cpp:144-147`, `README.md:31`
+- [ ] (suggestion, Claude Adv.) `std::to_string(double)` in summary text emits 6 fractional digits — noisy in aggregator UIs. Use `std::fixed << std::setprecision(2)` — `udp_bridge.cpp:1667-1671`
+- [ ] (suggestion, Copilot Adv.) No wrapper-side integration test for `diagnoseRemoteGiveups` (mutex discipline, map-update ordering, STALE path). Plan §4 deferred this as "verified at integration level"; flagging the coverage cost — `test/test_giveup_diagnostic.cpp` (gap)
+
+### Notes
+- Cross-source convergence on must-fix #1: both Claude Adv. (in-context sub-agent) and Copilot Adv. (CLI) independently flagged the parameter live-update gap. Strongest signal class per ADR-0013.
+- Process miss: this review was run **post-push**, not pre-push. AGENTS.md Post-Task Verification §5 requires pre-push. Captured in the broader pattern tracked at workspace umbrella issue #480.
+- One Copilot false positive dismissed: claim that `.agent/work-plans/issue-22/plan.md` is "review noise" — it's the canonical plan-first artifact per ADR-0013, ships with the PR by design.
+- Static analysis skipped: `cpplint` / `cppcheck` not installed on this host. CI will run them if configured upstream.
+- Plan §4's deferred "annunciator allowlist check" (Open Question 1) is still open — required during deployment integration, not blocking this PR.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -36,8 +36,13 @@ issue: 22
 **CI**: all-pass (Agent, Prepare, Upload results, Cleanup artifacts)
 
 ### Actions
-- [ ] Fix (udp_bridge.cpp:165–178): add `std::isfinite` per value and `warn_thresh <= error_thresh` cross-check in OnSetParameters validation; reject batch with actionable `result.reason`.
-- [ ] Fix (udp_bridge.cpp:1716): clamp `elapsed_s` to `>= 0` for `window_s` KeyValue (`stat.add("window_s", std::max(0.0, elapsed_s))`).
-- [ ] Fix (udp_bridge.h:180–185): update `diagnoseRemoteGiveups` docstring — drop the "last_giveup_*_ maps" reference, point to `giveup_rate_state_` / `GiveupRateState` from `giveup_diagnostic.h`.
-- [ ] Fix (README.md:19–21): clarify DiagnosticStatus is the default operator surface; per-event DEBUG log requires enabling DEBUG severity to land in `/rosout` / bags.
-- [ ] (Optional) Reply or dismiss Copilot's `as_double()` type-check thread — false positive (strict typing rejects mismatched `param set` server-side; `dynamic_typing` not enabled).
+- [x] Fix (udp_bridge.cpp OnSetParameters): refactored to single-pass validator. Added `validateGiveupThresholds` to `giveup_diagnostic.h` — rejects NaN/inf, negatives, and `warn > error` with operator-actionable reason strings. Callback computes proposed_warn/proposed_error from batch + current under `remote_nodes_mutex_`, then validates once.
+- [x] Fix (udp_bridge.cpp on_configure): same validator called after `get_parameter` so launch-line overrides (`-p resend_giveup_warn_rate_per_s:=…`) can't slip a bad pair past startup. Fails the lifecycle transition with `RCLCPP_ERROR` + `CallbackReturn::FAILURE` — scope expansion beyond Copilot's flagged surface, approved by user.
+- [x] Fix (udp_bridge.cpp:1716 → now 1740): `stat.add("window_s", std::max(0.0, elapsed_s))` so a backward clock jump (NTP correction, sim-time rewind) doesn't surface a negative published window.
+- [x] Fix (udp_bridge.h diagnoseRemoteGiveups docstring): dropped stale `last_giveup_*_` reference, points at `giveup_rate_state_` / `GiveupRateState` / `stepGiveupDiagnostic`.
+- [x] Fix (README.md diagnostic surface paragraph): DiagnosticStatus called out as the default surface; per-event DEBUG log capture now documented as requiring `--ros-args --log-level udp_bridge:=DEBUG` or `RCUTILS_LOGGING_SEVERITY_THRESHOLD=DEBUG`.
+- [x] Test coverage: +9 gtests in `test_giveup_diagnostic.cpp` for the validator — defaults pass, equal warn=error passes, 0/0 passes, negative warn/error rejected per side, NaN warn/error rejected per side, +inf rejected (finite check), inverted pair rejected with both values in the reason string. 65 → 74 tests, all passing.
+- [ ] (Optional) Reply or dismiss Copilot's `as_double()` type-check thread — false positive (strict typing rejects mismatched `param set` server-side; `dynamic_typing` not enabled). Deferred to user.
+
+### Notes
+- One scope expansion beyond Copilot's flagged surface: launch-line overrides bypass the OnSetParameters callback. Same bug class (NaN/negative/inverted pair → silently broken diagnostic), closed at the launch entry point too. Authorized via AskUserQuestion before committing.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -73,5 +73,5 @@ issue: 22
 **CI**: all-pass (Agent, Prepare, Upload results, Cleanup artifacts)
 
 ### Actions
-- [ ] Fix (`giveup_diagnostic.h:65–79`): add an explicit "no activity → OK" branch in `computeGiveupDiagnostic` so `current_count == prev_count` returns `{rate=0, level=OK}` before threshold comparison. With `>=` semantics and `validateGiveupThresholds` accepting 0/0, a zero-rate tick was firing ERROR forever (`0.0 >= 0.0`). Threshold logic should apply to actual give-up activity, not its absence.
-- [ ] Test (`test_giveup_diagnostic.cpp`): add regression test `ZeroDeltaWithZeroThresholdsStaysOk` (or similar) — `computeGiveupDiagnostic(5, 5, 1.0, 0.0, 0.0)` must return `{rate=0, level=OK}`. Also fix the misleading comment in the existing `ZeroThresholdsAreAccepted` validator test that incorrectly claimed "0/0 means every nonzero rate fires ERROR" — it would have fired on every rate including zero, which is the actual defect.
+- [x] Fix (`giveup_diagnostic.h`): added the "no activity → OK" short-circuit (`current_count == prev_count` returns rate=0/OK before threshold comparison). The function's edge-case docstring was extended with the new case.
+- [x] Test (`test_giveup_diagnostic.cpp`): 3 new gtests — `NoActivityReturnsOk` (current==prev with default thresholds), `ZeroDeltaWithZeroThresholdsStaysOk` (the round-3 regression), `ZeroWarnFiresOnAnyActivity` (companion — warn=0 still fires on real activity). Also rewrote the misleading comment in `ZeroThresholdsAreAccepted` to describe the actual semantics. 74 → 77 tests, all green.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -85,8 +85,8 @@ issue: 22
 **CI**: all-pass (Agent, Prepare, Upload results, Cleanup artifacts)
 
 ### Actions
-- [ ] Fix (`README.md` Diagnostic surface bullet): reword "the sender has abandoned resending packets" — the counter is bumped on the *receiver* side in `RemoteNode::getMissingPackets()` when a missing packet's first-request time exceeds `kSentPacketTTL` (the sender's retention window). The receiver gives up because the sender no longer has the packet to resend. Phrase as "missing packets abandoned by the resend protocol" with the TTL mechanism named.
-- [ ] (Optional) Resolve the round-4 `||` README thread on GitHub — same parser-level hallucination Copilot fired in round 2; source still uses single pipes throughout the table.
+- [x] Fix (`README.md` Diagnostic surface bullet): reworded to drop "sender has abandoned" framing. Now says "missing packets are abandoned by the resend protocol" with the actual mechanism named — receiver-side give-up at sender's retention TTL.
+- [x] Resolve round-4 `||` README thread on GitHub — repeat FP, same as round 2.
 
 ### Notes
 - Round-4 `||` claim is the second instance of the same hallucination on the same unchanged source (round-2 instance was resolved as FP). Copilot's own diff hunk in the comment body shows the correct single-pipe markup — the false claim is purely in the natural-language prose. Pattern: this specific false positive may keep recurring on each re-review pass. Worth noting for future agents that "yet another `||` claim against this table" should be triaged as FP without re-investigating.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -26,3 +26,18 @@ issue: 22
 - One Copilot false positive dismissed: claim that `.agent/work-plans/issue-22/plan.md` is "review noise" — it's the canonical plan-first artifact per ADR-0013, ships with the PR by design.
 - Static analysis skipped: `cpplint` / `cppcheck` not installed on this host. CI will run them if configured upstream.
 - Plan §4's deferred "annunciator allowlist check" (Open Question 1) is still open — required during deployment integration, not blocking this PR.
+
+## External Review
+**Status**: complete
+**When**: 2026-05-20 18:50 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #24 — 1 review (Copilot), 5 inline comments, 4 valid, 1 false positive
+**CI**: all-pass (Agent, Prepare, Upload results, Cleanup artifacts)
+
+### Actions
+- [ ] Fix (udp_bridge.cpp:165–178): add `std::isfinite` per value and `warn_thresh <= error_thresh` cross-check in OnSetParameters validation; reject batch with actionable `result.reason`.
+- [ ] Fix (udp_bridge.cpp:1716): clamp `elapsed_s` to `>= 0` for `window_s` KeyValue (`stat.add("window_s", std::max(0.0, elapsed_s))`).
+- [ ] Fix (udp_bridge.h:180–185): update `diagnoseRemoteGiveups` docstring — drop the "last_giveup_*_ maps" reference, point to `giveup_rate_state_` / `GiveupRateState` from `giveup_diagnostic.h`.
+- [ ] Fix (README.md:19–21): clarify DiagnosticStatus is the default operator surface; per-event DEBUG log requires enabling DEBUG severity to land in `/rosout` / bags.
+- [ ] (Optional) Reply or dismiss Copilot's `as_double()` type-check thread — false positive (strict typing rejects mismatched `param set` server-side; `dynamic_typing` not enabled).

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -75,3 +75,18 @@ issue: 22
 ### Actions
 - [x] Fix (`giveup_diagnostic.h`): added the "no activity → OK" short-circuit (`current_count == prev_count` returns rate=0/OK before threshold comparison). The function's edge-case docstring was extended with the new case.
 - [x] Test (`test_giveup_diagnostic.cpp`): 3 new gtests — `NoActivityReturnsOk` (current==prev with default thresholds), `ZeroDeltaWithZeroThresholdsStaysOk` (the round-3 regression), `ZeroWarnFiresOnAnyActivity` (companion — warn=0 still fires on real activity). Also rewrote the misleading comment in `ZeroThresholdsAreAccepted` to describe the actual semantics. 74 → 77 tests, all green.
+
+## External Review (round 4)
+**Status**: complete
+**When**: 2026-05-20 23:55 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #24 at `b5946c2` — Copilot's fourth re-review. 2 new inline comments — 1 valid (README wording), 1 false positive (repeat `||` hallucination).
+**CI**: all-pass (Agent, Prepare, Upload results, Cleanup artifacts)
+
+### Actions
+- [ ] Fix (`README.md` Diagnostic surface bullet): reword "the sender has abandoned resending packets" — the counter is bumped on the *receiver* side in `RemoteNode::getMissingPackets()` when a missing packet's first-request time exceeds `kSentPacketTTL` (the sender's retention window). The receiver gives up because the sender no longer has the packet to resend. Phrase as "missing packets abandoned by the resend protocol" with the TTL mechanism named.
+- [ ] (Optional) Resolve the round-4 `||` README thread on GitHub — same parser-level hallucination Copilot fired in round 2; source still uses single pipes throughout the table.
+
+### Notes
+- Round-4 `||` claim is the second instance of the same hallucination on the same unchanged source (round-2 instance was resolved as FP). Copilot's own diff hunk in the comment body shows the correct single-pipe markup — the false claim is purely in the natural-language prose. Pattern: this specific false positive may keep recurring on each re-review pass. Worth noting for future agents that "yet another `||` claim against this table" should be triaged as FP without re-investigating.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -46,3 +46,17 @@ issue: 22
 
 ### Notes
 - One scope expansion beyond Copilot's flagged surface: launch-line overrides bypass the OnSetParameters callback. Same bug class (NaN/negative/inverted pair → silently broken diagnostic), closed at the launch entry point too. Authorized via AskUserQuestion before committing.
+
+## External Review (round 2)
+**Status**: complete
+**When**: 2026-05-20 22:00 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #24 at `87e8b6e` — Copilot re-reviewed after the round-1 push. 3 new inline comments; round-1's 5 comments are now stale (concerns addressed by the round-1 push).
+**CI**: all-pass (Agent, Prepare, Upload results, Cleanup artifacts)
+
+### Actions
+- [ ] Fix (udp_bridge.cpp:1703): drop the `:1271` line-number citation in the `diagnoseRemoteGiveups` lock comment — line 1271 is unrelated (TopicStatisticsArray code); the actual lock-order rationale lives at lines 1371–1374. Either describe the invariant in words or point at `remote_node.h`'s `resendGiveupCount()` declaration.
+- [ ] Decide scope (udp_bridge.cpp:152): Copilot flagged that `declare_parameter` inside `on_configure` throws on a second cleanup→configure cycle. The same pattern applies to every existing `declare_parameter` in this node (e.g., `maximum_packet_size` at line 115). Reconfigure was broken pre-PR. Options: (a) add `has_parameter()` guards to just my new params (cosmetic; doesn't fix reconfigure since line 115 throws first), (b) file a separate issue for repo-wide cleanup, (c) leave it (matches existing pattern). Surfacing to user.
+- [ ] (Optional) Resolve README `||` thread on GitHub — false positive (table at lines 30–33 uses single pipes; Copilot's claim does not match the source).
+- [ ] (Optional) Resolve 5 stale round-1 threads on GitHub — all addressed by the round-1 push.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -63,3 +63,15 @@ issue: 22
 ### Notes
 - `declareIfMissing` is a template member function defined inline in `udp_bridge.h` — needs `has_parameter()` on the `LifecycleNode` base, so couldn't go in `giveup_diagnostic.h` (the pure header). No new unit test: testing the guard requires bringing up the node and a real cleanup→configure cycle, which is out of proportion for a 2-line guard. The build and existing 74 tests still pass.
 - Scope creep authorized in advance — Copilot flagged only my new params, but the pre-existing pattern (lines 87, 94, 115, …, 387) had the same defect. Fixing only my pair would have been cosmetic; the reconfigure cycle would still throw at line 87. Repo-wide fix lands the property Copilot wanted.
+
+## External Review (round 3)
+**Status**: complete
+**When**: 2026-05-20 22:25 -04:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #24 at `be6e9e6` — Copilot's third re-review. 1 new inline comment, classified Valid (real defect).
+**CI**: all-pass (Agent, Prepare, Upload results, Cleanup artifacts)
+
+### Actions
+- [ ] Fix (`giveup_diagnostic.h:65–79`): add an explicit "no activity → OK" branch in `computeGiveupDiagnostic` so `current_count == prev_count` returns `{rate=0, level=OK}` before threshold comparison. With `>=` semantics and `validateGiveupThresholds` accepting 0/0, a zero-rate tick was firing ERROR forever (`0.0 >= 0.0`). Threshold logic should apply to actual give-up activity, not its absence.
+- [ ] Test (`test_giveup_diagnostic.cpp`): add regression test `ZeroDeltaWithZeroThresholdsStaysOk` (or similar) — `computeGiveupDiagnostic(5, 5, 1.0, 0.0, 0.0)` must return `{rate=0, level=OK}`. Also fix the misleading comment in the existing `ZeroThresholdsAreAccepted` validator test that incorrectly claimed "0/0 means every nonzero rate fires ERROR" — it would have fired on every rate including zero, which is the actual defect.

--- a/.agent/work-plans/issue-22/progress.md
+++ b/.agent/work-plans/issue-22/progress.md
@@ -56,7 +56,10 @@ issue: 22
 **CI**: all-pass (Agent, Prepare, Upload results, Cleanup artifacts)
 
 ### Actions
-- [ ] Fix (udp_bridge.cpp:1703): drop the `:1271` line-number citation in the `diagnoseRemoteGiveups` lock comment — line 1271 is unrelated (TopicStatisticsArray code); the actual lock-order rationale lives at lines 1371–1374. Either describe the invariant in words or point at `remote_node.h`'s `resendGiveupCount()` declaration.
-- [ ] Decide scope (udp_bridge.cpp:152): Copilot flagged that `declare_parameter` inside `on_configure` throws on a second cleanup→configure cycle. The same pattern applies to every existing `declare_parameter` in this node (e.g., `maximum_packet_size` at line 115). Reconfigure was broken pre-PR. Options: (a) add `has_parameter()` guards to just my new params (cosmetic; doesn't fix reconfigure since line 115 throws first), (b) file a separate issue for repo-wide cleanup, (c) leave it (matches existing pattern). Surfacing to user.
-- [ ] (Optional) Resolve README `||` thread on GitHub — false positive (table at lines 30–33 uses single pipes; Copilot's claim does not match the source).
-- [ ] (Optional) Resolve 5 stale round-1 threads on GitHub — all addressed by the round-1 push.
+- [x] Fix (diagnoseRemoteGiveups lock comment): dropped both stale line-number citations (`udp_bridge.cpp:1271` and `diagnoseConnection() at line 1543`). Replaced with the durable invariants (`RemoteNode::resendGiveupCount()` takes only `RemoteNode::state_mutex_`; `STALE` return mirrors `diagnoseConnection()` above).
+- [x] Scope decision (declare_parameter reconfigure-safety): user authorized repo-wide fix in this PR. Added `declareIfMissing<T>(name, default)` private template helper to `UDPBridge`; replaced all 18 `declare_parameter` call sites in `on_configure` (port, maximum_packet_size, resend-giveup pair, and the remotes/connections/topics loops). Reconfigure cycle (cleanup→configure) now reentrant for parameter declaration.
+- [ ] (Pending) Resolve 4 unresolved round-1 threads + 1 round-2 `||` FP thread on GitHub. (Round-1 `as_double()` FP already resolved.)
+
+### Notes
+- `declareIfMissing` is a template member function defined inline in `udp_bridge.h` — needs `has_parameter()` on the `LifecycleNode` base, so couldn't go in `giveup_diagnostic.h` (the pure header). No new unit test: testing the guard requires bringing up the node and a real cleanup→configure cycle, which is out of proportion for a 2-line guard. The build and existing 74 tests still pass.
+- Scope creep authorized in advance — Copilot flagged only my new params, but the pre-existing pattern (lines 87, 94, 115, …, 387) had the same defect. Fixing only my pair would have been cosmetic; the reconfigure cycle would still throw at line 87. Repo-wide fix lands the property Copilot wanted.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ via [`diagnostic_updater`](https://github.com/ros/diagnostics) at ~1 Hz. Two tas
   the rate at which the sender has abandoned resending packets (give-up events). High give-up rates
   indicate sustained packet loss on the link beyond what the resend protocol can compensate.
 
-  The per-event log (the `Giving up on resend of packet …` message) is emitted at DEBUG severity, so
-  it appears in bag recordings for forensic analysis but does not pollute live operator log panels.
-  Operators see the aggregated rate via this DiagnosticStatus instead.
+  The aggregated DiagnosticStatus is the default operator surface — it is published whether or not
+  any per-event logs are enabled. The per-event log (the `Giving up on resend of packet …` message)
+  is emitted at DEBUG severity, which is below the default ROS 2 log threshold (INFO). To capture
+  per-event detail in `/rosout` (and any `/rosout` bag recording), lower the node's log level — for
+  example, launch with `--ros-args --log-level udp_bridge:=DEBUG` or set
+  `RCUTILS_LOGGING_SEVERITY_THRESHOLD=DEBUG`.
 
 ### Resend give-up thresholds
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,40 @@ It allows the selection of topics to forward and to rate limit them. Data is com
 
 Multiple data paths can be used for redundancy allowing seamless operation using wifi, mesh radios, cellular links, or satellite internet.
 
+## Diagnostic surface
+
+The bridge publishes [`diagnostic_msgs/DiagnosticStatus`](https://docs.ros2.org/latest/api/diagnostic_msgs/msg/DiagnosticStatus.html)
+via [`diagnostic_updater`](https://github.com/ros/diagnostics) at ~1 Hz. Two task families are emitted:
+
+- **Per-connection** — `udp_bridge <name>: <remote>: <connection_id>` — surfaces tx/rx byte rates,
+  rx staleness, and tx failure/drop conditions for one outbound or inbound socket.
+- **Per-remote resend give-ups** — `udp_bridge <name>: <remote>: resend give-ups` (issue #22) — surfaces
+  the rate at which the sender has abandoned resending packets (give-up events). High give-up rates
+  indicate sustained packet loss on the link beyond what the resend protocol can compensate.
+
+  The per-event log (the `Giving up on resend of packet …` message) is emitted at DEBUG severity, so
+  it appears in bag recordings for forensic analysis but does not pollute live operator log panels.
+  Operators see the aggregated rate via this DiagnosticStatus instead.
+
+### Resend give-up thresholds
+
+Two ROS 2 parameters tune when the per-remote give-up diagnostic transitions between OK / WARN / ERROR levels:
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `resend_giveup_warn_rate_per_s` | `5.0` | give-up rate ≥ this fires WARN |
+| `resend_giveup_error_rate_per_s` | `50.0` | give-up rate ≥ this fires ERROR (takes priority over WARN) |
+
+Defaults calibrated against the 2026-05-19 BizzyBoat deployment (~3.9/s steady storm fires WARN,
+~700/s burst fires ERROR). Adjust per deployment via the standard ROS 2 parameter mechanism.
+
+KeyValue pairs published on each task:
+
+- `remote` — remote name
+- `give_ups_total` — cumulative give-up count since bridge start (also available on `Remote.msg.resend_giveup_count`)
+- `give_up_rate_per_s` — rate over the window since the previous publish
+- `window_s` — length of that window (typically ~1 s)
+- `warn_threshold_per_s`, `error_threshold_per_s` — the active thresholds (for operator-side dashboards)
+
+The rate is computed as `(current - previous) / elapsed`. On counter reset (sender restart, per the
+behavior observed in [#21](https://github.com/rolker/udp_bridge/issues/21)), the published rate is `0`.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ via [`diagnostic_updater`](https://github.com/ros/diagnostics) at ~1 Hz. Two tas
 - **Per-connection** — `udp_bridge <name>: <remote>: <connection_id>` — surfaces tx/rx byte rates,
   rx staleness, and tx failure/drop conditions for one outbound or inbound socket.
 - **Per-remote resend give-ups** — `udp_bridge <name>: <remote>: resend give-ups` (issue #22) — surfaces
-  the rate at which the sender has abandoned resending packets (give-up events). High give-up rates
-  indicate sustained packet loss on the link beyond what the resend protocol can compensate.
+  the rate at which missing packets are abandoned by the resend protocol. A give-up event is recorded
+  on the receiving bridge when a missing packet's first-request timestamp passes the sender's
+  retention TTL (the sender no longer has the packet buffered, so further resend requests are futile).
+  High give-up rates indicate sustained packet loss on the link beyond what the resend protocol can
+  compensate.
 
   The aggregated DiagnosticStatus is the default operator surface — it is published whether or not
   any per-event logs are enabled. The per-event log (the `Giving up on resend of packet …` message)

--- a/udp_bridge/CMakeLists.txt
+++ b/udp_bridge/CMakeLists.txt
@@ -120,6 +120,9 @@ if(BUILD_TESTING)
   ament_add_gtest(test_connection_cleanup test/test_connection_cleanup.cpp)
   target_compile_definitions(test_connection_cleanup PRIVATE UDP_BRIDGE_BUILD_TESTING)
   target_link_libraries(test_connection_cleanup ${PROJECT_NAME})
+
+  ament_add_gtest(test_giveup_diagnostic test/test_giveup_diagnostic.cpp)
+  target_link_libraries(test_giveup_diagnostic ${PROJECT_NAME})
 endif()
 
 ament_package()

--- a/udp_bridge/include/udp_bridge/giveup_diagnostic.h
+++ b/udp_bridge/include/udp_bridge/giveup_diagnostic.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "rclcpp/time.hpp"
 
 namespace udp_bridge
 {
@@ -76,6 +77,56 @@ inline GiveupDiagnostic computeGiveupDiagnostic(
     d.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
 
   return d;
+}
+
+// Per-remote state for the rate-window calculation. The UDPBridge
+// wrapper holds one instance per remote and snapshots/updates it via
+// stepGiveupDiagnostic() under remote_nodes_mutex_. Carrying state in
+// a struct (rather than two parallel maps) makes the map-update
+// ordering testable without bringing up a UDPBridge node — see
+// stepGiveupDiagnostic() below.
+struct GiveupRateState
+{
+  uint32_t last_count {0};
+  rclcpp::Time last_publish_time;
+  // has_previous distinguishes "no prior call yet" from "prior call
+  // observed count=0 at time=0", which would otherwise be ambiguous
+  // for a freshly-started bridge whose clock hasn't yet reached
+  // wall-time. Without this flag the first call would compute
+  // elapsed_s = (now - default_time) ≈ now.seconds(), which fires a
+  // spurious huge rate on the very first publish.
+  bool has_previous {false};
+};
+
+// Stateful step: snapshots `state`, computes a diagnostic from the
+// (prev, current, elapsed) tuple, and writes the new sample back
+// before returning. Caller holds whatever lock guards `state`.
+//
+// First call (state.has_previous == false): treated as zero-elapsed
+// (rate=0, level=OK). State is updated so the second call has a
+// baseline. This intentionally suppresses a "first window" rate even
+// if current_count > 0 — the wrapper has no way to know how long
+// those give-ups accumulated over, so reporting a rate would be
+// misleading.
+inline GiveupDiagnostic stepGiveupDiagnostic(
+    GiveupRateState& state,
+    uint32_t current_count,
+    rclcpp::Time now_time,
+    double warn_thresh,
+    double error_thresh)
+{
+  uint32_t prev_count = 0;
+  double elapsed_s = 0.0;
+  if(state.has_previous)
+  {
+    prev_count = state.last_count;
+    elapsed_s = (now_time - state.last_publish_time).seconds();
+  }
+  state.last_count = current_count;
+  state.last_publish_time = now_time;
+  state.has_previous = true;
+  return computeGiveupDiagnostic(
+      prev_count, current_count, elapsed_s, warn_thresh, error_thresh);
 }
 
 }  // namespace udp_bridge

--- a/udp_bridge/include/udp_bridge/giveup_diagnostic.h
+++ b/udp_bridge/include/udp_bridge/giveup_diagnostic.h
@@ -39,7 +39,14 @@ struct GiveupDiagnostic
 //                         rewind across a sender restart)
 //                         → rate_per_s = 0, level = OK; total reflects
 //                         current_count.
-//  - Threshold transitions:
+//  - No activity:       current_count == prev_count
+//                         → rate_per_s = 0, level = OK regardless of
+//                         thresholds. Threshold semantics apply to
+//                         give-up activity, not its absence; without
+//                         this short-circuit, a 0/0 threshold pair
+//                         (allowed by validateGiveupThresholds) would
+//                         fire ERROR on every quiet tick via `0 >= 0`.
+//  - Threshold transitions (current_count > prev_count, elapsed_s > 0):
 //      rate >= error_thresh    → level = ERROR
 //      rate >= warn_thresh     → level = WARN
 //      otherwise               → level = OK
@@ -63,6 +70,18 @@ inline GiveupDiagnostic computeGiveupDiagnostic(
   // both collapse to "no measurable rate this interval". elapsed_s < 0
   // covers clock jumps from sim time or NTP corrections.
   if (current_count < prev_count || elapsed_s <= 0.0)
+  {
+    d.rate_per_s = 0.0;
+    d.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    return d;
+  }
+
+  // No activity this window: report OK regardless of thresholds. The
+  // `>=` comparisons below would otherwise fire WARN/ERROR for a zero
+  // rate when warn_thresh / error_thresh are 0 — a permanently-non-OK
+  // diagnostic. Caught by Copilot round 3 on PR #24; regression test
+  // ZeroDeltaWithZeroThresholdsStaysOk.
+  if (current_count == prev_count)
   {
     d.rate_per_s = 0.0;
     d.level = diagnostic_msgs::msg::DiagnosticStatus::OK;

--- a/udp_bridge/include/udp_bridge/giveup_diagnostic.h
+++ b/udp_bridge/include/udp_bridge/giveup_diagnostic.h
@@ -1,7 +1,9 @@
 #ifndef UDP_BRIDGE_GIVEUP_DIAGNOSTIC_H
 #define UDP_BRIDGE_GIVEUP_DIAGNOSTIC_H
 
+#include <cmath>
 #include <cstdint>
+#include <string>
 
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "rclcpp/time.hpp"
@@ -127,6 +129,50 @@ inline GiveupDiagnostic stepGiveupDiagnostic(
   state.has_previous = true;
   return computeGiveupDiagnostic(
       prev_count, current_count, elapsed_s, warn_thresh, error_thresh);
+}
+
+// Result of validating a proposed (warn, error) threshold pair.
+// `ok == true` means the pair is safe to apply; `reason` is empty.
+// `ok == false` means the pair is invalid; `reason` carries an
+// operator-facing explanation suitable for SetParametersResult.reason
+// or an on_configure ERROR log.
+struct GiveupThresholdValidation
+{
+  bool ok;
+  std::string reason;
+};
+
+// Validate a proposed (warn, error) threshold pair before applying.
+// Rejects:
+//  - NaN / inf  — non-finite values silently disable the diagnostic
+//                 because NaN comparisons always return false.
+//  - Negative   — rate is always >= 0, so a negative threshold never
+//                 fires; an operator-error signal, not a configuration.
+//  - warn > err — inverts the WARN band: rates above warn would also
+//                 be above error and fire ERROR, never WARN.
+// The error string identifies which parameter is bad so an operator
+// can correct it from `ros2 param set` feedback without digging
+// through logs.
+inline GiveupThresholdValidation validateGiveupThresholds(
+    double warn, double error)
+{
+  if(!std::isfinite(warn))
+    return {false, "resend_giveup_warn_rate_per_s must be finite; got "
+                   + std::to_string(warn)};
+  if(warn < 0.0)
+    return {false, "resend_giveup_warn_rate_per_s must be >= 0; got "
+                   + std::to_string(warn)};
+  if(!std::isfinite(error))
+    return {false, "resend_giveup_error_rate_per_s must be finite; got "
+                   + std::to_string(error)};
+  if(error < 0.0)
+    return {false, "resend_giveup_error_rate_per_s must be >= 0; got "
+                   + std::to_string(error)};
+  if(warn > error)
+    return {false, "resend_giveup_warn_rate_per_s (" + std::to_string(warn)
+                   + ") must be <= resend_giveup_error_rate_per_s ("
+                   + std::to_string(error) + ")"};
+  return {true, ""};
 }
 
 }  // namespace udp_bridge

--- a/udp_bridge/include/udp_bridge/giveup_diagnostic.h
+++ b/udp_bridge/include/udp_bridge/giveup_diagnostic.h
@@ -1,0 +1,83 @@
+#ifndef UDP_BRIDGE_GIVEUP_DIAGNOSTIC_H
+#define UDP_BRIDGE_GIVEUP_DIAGNOSTIC_H
+
+#include <cstdint>
+
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+
+namespace udp_bridge
+{
+
+// Per-remote resend-give-up diagnostic snapshot. Computed by
+// computeGiveupDiagnostic() from a counter pair + elapsed time, then
+// surfaced by UDPBridge's diagnostic_updater task. Pure logic, no
+// node / clock / mutex dependencies — the wrapper holds those.
+struct GiveupDiagnostic
+{
+  // diagnostic_msgs::msg::DiagnosticStatus level value (OK / WARN / ERROR).
+  uint8_t level;
+  // Give-ups per second over the elapsed interval. Zero on first call,
+  // zero on counter reset, zero on zero-elapsed.
+  double rate_per_s;
+  // Cumulative count from RemoteNode::resendGiveupCount() — surfaced
+  // for operators who want the total alongside the rate.
+  uint32_t total;
+};
+
+// Compute the diagnostic from a counter pair + elapsed window.
+//
+// Edge cases (tested in test_giveup_diagnostic.cpp):
+//  - First call:        prev_count == 0 && elapsed_s == 0
+//                         → rate_per_s = 0, level = OK.
+//  - Zero elapsed time: elapsed_s == 0 (or negative, e.g. clock jump)
+//                         → rate_per_s = 0, level = OK. Never divides.
+//  - Counter reset:     current_count < prev_count
+//                         (per #21, the counter has been observed to
+//                         rewind across a sender restart)
+//                         → rate_per_s = 0, level = OK; total reflects
+//                         current_count.
+//  - Threshold transitions:
+//      rate >= error_thresh    → level = ERROR
+//      rate >= warn_thresh     → level = WARN
+//      otherwise               → level = OK
+//
+// The function is intentionally a pure free function so the test can
+// exercise it without a UDPBridge instance or a clock — the
+// time-dependence is moved out into the caller. Defined inline because
+// the body is small and pure; this avoids needing a separate .cpp +
+// CMakeLists entry for ~10 lines of arithmetic.
+inline GiveupDiagnostic computeGiveupDiagnostic(
+    uint32_t prev_count,
+    uint32_t current_count,
+    double elapsed_s,
+    double warn_thresh,
+    double error_thresh)
+{
+  GiveupDiagnostic d;
+  d.total = current_count;
+
+  // Counter reset (sender restart per #21) and zero-or-negative elapsed
+  // both collapse to "no measurable rate this interval". elapsed_s < 0
+  // covers clock jumps from sim time or NTP corrections.
+  if (current_count < prev_count || elapsed_s <= 0.0)
+  {
+    d.rate_per_s = 0.0;
+    d.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    return d;
+  }
+
+  d.rate_per_s = static_cast<double>(current_count - prev_count) / elapsed_s;
+
+  if (d.rate_per_s >= error_thresh)
+    d.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+  else if (d.rate_per_s >= warn_thresh)
+    d.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+  else
+    d.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+
+  return d;
+}
+
+}  // namespace udp_bridge
+
+#endif  // UDP_BRIDGE_GIVEUP_DIAGNOSTIC_H

--- a/udp_bridge/include/udp_bridge/udp_bridge.h
+++ b/udp_bridge/include/udp_bridge/udp_bridge.h
@@ -176,6 +176,15 @@ private:
                           const std::string& connection_id,
                           diagnostic_updater::DiagnosticStatusWrapper& stat);
 
+  /// Populate a diagnostic status message summarizing resend give-up
+  /// activity for one remote. Computes rate from a window since the
+  /// previous publish (tracked in last_giveup_*_ maps guarded by
+  /// remote_nodes_mutex_). The rate-vs-threshold logic lives in the
+  /// computeGiveupDiagnostic() free function (giveup_diagnostic.h) so
+  /// it can be unit-tested without a UDPBridge instance.
+  void diagnoseRemoteGiveups(const std::string& remote_name,
+                             diagnostic_updater::DiagnosticStatusWrapper& stat);
+
   /// Timer callback where info on available topics are periodically reported
   void bridgeInfoCallback();
 
@@ -298,6 +307,22 @@ private:
 
   std::map<std::string, std::shared_ptr<RemoteNode> > remote_nodes_;
   mutable std::mutex remote_nodes_mutex_;
+
+  // Per-remote diagnostic state for the resend-give-up rate computation
+  // (issue #22). Guarded by remote_nodes_mutex_ — extended scope, not a
+  // new mutex; entries are short integers/timestamps and the diagnostic
+  // callback's read is brief. Cleared in on_cleanup alongside
+  // diagnostic_task_names_ so an activate→deactivate→activate cycle
+  // starts from a known state.
+  std::map<std::string, uint32_t> last_giveup_count_;
+  std::map<std::string, rclcpp::Time> last_giveup_publish_time_;
+
+  // Thresholds for the resend-give-up DiagnosticStatus level. Declared
+  // as ROS 2 parameters in on_configure so deployments can override
+  // without rebuild; defaults calibrated against the 2026-05-19
+  // BizzyBoat storm (~3.9/s steady, ~700/s burst).
+  double resend_giveup_warn_rate_per_s_ {5.0};
+  double resend_giveup_error_rate_per_s_ {50.0};
 };
 
 } // namespace udp_bridge

--- a/udp_bridge/include/udp_bridge/udp_bridge.h
+++ b/udp_bridge/include/udp_bridge/udp_bridge.h
@@ -188,6 +188,20 @@ private:
   void diagnoseRemoteGiveups(const std::string& remote_name,
                              diagnostic_updater::DiagnosticStatusWrapper& stat);
 
+  /// Lifecycle-safe wrapper around `declare_parameter`. Parameters
+  /// declared during `on_configure` persist across a
+  /// cleanup→configure transition (`on_cleanup` does not
+  /// `undeclare_parameter`), so a second `declare_parameter` for the
+  /// same name throws `ParameterAlreadyDeclaredException` and breaks
+  /// reconfiguration. Use this everywhere in `on_configure` instead
+  /// of bare `declare_parameter` to keep the lifecycle reentrant.
+  template <typename T>
+  void declareIfMissing(const std::string& name, const T& default_value)
+  {
+    if(!has_parameter(name))
+      declare_parameter(name, default_value);
+  }
+
   /// Timer callback where info on available topics are periodically reported
   void bridgeInfoCallback();
 

--- a/udp_bridge/include/udp_bridge/udp_bridge.h
+++ b/udp_bridge/include/udp_bridge/udp_bridge.h
@@ -23,6 +23,7 @@
 #include "udp_bridge_interfaces/msg/topic_statistics_array.hpp"
 
 #include "connection.h"
+#include "giveup_diagnostic.h"
 #include "packet.h"
 #include "defragmenter.h"
 #include "udp_bridge/types.h"
@@ -308,21 +309,35 @@ private:
   std::map<std::string, std::shared_ptr<RemoteNode> > remote_nodes_;
   mutable std::mutex remote_nodes_mutex_;
 
-  // Per-remote diagnostic state for the resend-give-up rate computation
-  // (issue #22). Guarded by remote_nodes_mutex_ — extended scope, not a
-  // new mutex; entries are short integers/timestamps and the diagnostic
-  // callback's read is brief. Cleared in on_cleanup alongside
-  // diagnostic_task_names_ so an activate→deactivate→activate cycle
-  // starts from a known state.
-  std::map<std::string, uint32_t> last_giveup_count_;
-  std::map<std::string, rclcpp::Time> last_giveup_publish_time_;
+  // Per-remote diagnostic state for the resend-give-up rate
+  // computation (issue #22). Guarded by remote_nodes_mutex_ —
+  // extended scope, not a new mutex; entries are small
+  // integer/timestamp structs and the diagnostic callback's read is
+  // brief. Cleared in on_cleanup alongside diagnostic_task_names_ so
+  // an activate→deactivate→activate cycle starts from a known state.
+  // Consolidating the (count, time, has_previous) tuple into one
+  // struct (vs. two parallel maps) makes the wrapper's update logic
+  // testable via the stepGiveupDiagnostic helper in
+  // giveup_diagnostic.h — see test_giveup_diagnostic.cpp's
+  // wrapper-side cases.
+  std::map<std::string, GiveupRateState> giveup_rate_state_;
 
   // Thresholds for the resend-give-up DiagnosticStatus level. Declared
   // as ROS 2 parameters in on_configure so deployments can override
   // without rebuild; defaults calibrated against the 2026-05-19
-  // BizzyBoat storm (~3.9/s steady, ~700/s burst).
+  // BizzyBoat storm (~3.9/s steady, ~700/s burst). Live-updated via
+  // an OnSetParameters callback (handle below), so operators can tune
+  // mid-storm without restarting the bridge. Reads/writes are guarded
+  // by remote_nodes_mutex_ — diagnoseRemoteGiveups holds the lock when
+  // it samples these values, the callback holds the lock when it
+  // updates them.
   double resend_giveup_warn_rate_per_s_ {5.0};
   double resend_giveup_error_rate_per_s_ {50.0};
+
+  // Handle for the parameter-change callback. Reset in on_cleanup so
+  // re-configure cycles don't accumulate stale handles.
+  rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr
+    on_set_parameters_handle_;
 };
 
 } // namespace udp_bridge

--- a/udp_bridge/include/udp_bridge/udp_bridge.h
+++ b/udp_bridge/include/udp_bridge/udp_bridge.h
@@ -179,10 +179,12 @@ private:
 
   /// Populate a diagnostic status message summarizing resend give-up
   /// activity for one remote. Computes rate from a window since the
-  /// previous publish (tracked in last_giveup_*_ maps guarded by
-  /// remote_nodes_mutex_). The rate-vs-threshold logic lives in the
-  /// computeGiveupDiagnostic() free function (giveup_diagnostic.h) so
-  /// it can be unit-tested without a UDPBridge instance.
+  /// previous publish (per-remote state kept in giveup_rate_state_, a
+  /// std::map<std::string, GiveupRateState> guarded by
+  /// remote_nodes_mutex_; step + threshold-evaluation live in
+  /// stepGiveupDiagnostic() / computeGiveupDiagnostic() in
+  /// giveup_diagnostic.h so they can be unit-tested without a
+  /// UDPBridge instance.
   void diagnoseRemoteGiveups(const std::string& remote_name,
                              diagnostic_updater::DiagnosticStatusWrapper& stat);
 

--- a/udp_bridge/src/remote_node.cpp
+++ b/udp_bridge/src/remote_node.cpp
@@ -326,7 +326,7 @@ ResendRequest RemoteNode::getMissingPacketsAt(rclcpp::Time now)
     // zero-attempts entry would otherwise log "after 0 attempts"
     // silently.
     assert(s.attempts > 0);
-    RCLCPP_WARN_STREAM(logger_,
+    RCLCPP_DEBUG_STREAM(logger_,
       "Giving up on resend of packet " << m << " from remote '"
       << name_ << "' after " << s.attempts
       << " attempts (first requested "

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -47,6 +47,7 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <poll.h>
+#include <algorithm>
 #include <iomanip>
 #include <sstream>
 #include <unordered_set>
@@ -149,6 +150,23 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
   declare_parameter("resend_giveup_error_rate_per_s", resend_giveup_error_rate_per_s_);
   resend_giveup_warn_rate_per_s_ = get_parameter("resend_giveup_warn_rate_per_s").as_double();
   resend_giveup_error_rate_per_s_ = get_parameter("resend_giveup_error_rate_per_s").as_double();
+  // Validate launch-time values. Launch-line overrides
+  // (`-p resend_giveup_warn_rate_per_s:=100.0`) bypass the
+  // OnSetParameters callback below, so a bad pair would otherwise
+  // silently disable or invert the diagnostic. Fail fast and visibly
+  // — same bug class as a runtime `ros2 param set`, closed at the same
+  // entry point.
+  {
+    auto validation = validateGiveupThresholds(
+      resend_giveup_warn_rate_per_s_, resend_giveup_error_rate_per_s_);
+    if(!validation.ok)
+    {
+      RCLCPP_ERROR(get_logger(),
+        "Invalid resend give-up thresholds at on_configure: %s",
+        validation.reason.c_str());
+      return CallbackReturn::FAILURE;
+    }
+  }
   RCLCPP_INFO_STREAM(get_logger(),
     "resend_giveup thresholds: warn=" << resend_giveup_warn_rate_per_s_
     << "/s, error=" << resend_giveup_error_rate_per_s_ << "/s");
@@ -159,43 +177,49 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
     {
       rcl_interfaces::msg::SetParametersResult result;
       result.successful = true;
-      // Validate first so we can reject the whole batch atomically.
-      // Negative thresholds would never fire (rate is always >= 0)
-      // and indicate operator error rather than intent.
-      for(const auto& p: params)
-      {
-        if(p.get_name() == "resend_giveup_warn_rate_per_s" ||
-           p.get_name() == "resend_giveup_error_rate_per_s")
-        {
-          if(p.as_double() < 0.0)
-          {
-            result.successful = false;
-            result.reason = p.get_name() + " must be >= 0; got "
-              + std::to_string(p.as_double());
-            return result;
-          }
-        }
-      }
-      // Apply under the same lock the reader takes — keeps a torn
-      // read of the two threshold fields impossible.
+      // Take the reader's lock so the (read current → validate batch →
+      // apply) sequence is atomic against another concurrent set call,
+      // and so the reader can never observe a half-applied pair.
       std::lock_guard<std::mutex> lock(remote_nodes_mutex_);
+      // Compute the (warn, error) pair that would result from applying
+      // the batch on top of the current values, then validate the
+      // combined state in one pass — catches per-value problems
+      // (NaN/inf, negative) and cross-value problems (warn > error)
+      // together. See validateGiveupThresholds() in giveup_diagnostic.h.
+      bool warn_changed = false;
+      bool error_changed = false;
+      double proposed_warn = resend_giveup_warn_rate_per_s_;
+      double proposed_error = resend_giveup_error_rate_per_s_;
       for(const auto& p: params)
       {
         if(p.get_name() == "resend_giveup_warn_rate_per_s")
         {
-          resend_giveup_warn_rate_per_s_ = p.as_double();
-          RCLCPP_INFO_STREAM(get_logger(),
-            "resend_giveup_warn_rate_per_s updated to "
-            << resend_giveup_warn_rate_per_s_ << "/s");
+          proposed_warn = p.as_double();
+          warn_changed = true;
         }
         else if(p.get_name() == "resend_giveup_error_rate_per_s")
         {
-          resend_giveup_error_rate_per_s_ = p.as_double();
-          RCLCPP_INFO_STREAM(get_logger(),
-            "resend_giveup_error_rate_per_s updated to "
-            << resend_giveup_error_rate_per_s_ << "/s");
+          proposed_error = p.as_double();
+          error_changed = true;
         }
       }
+      auto validation = validateGiveupThresholds(proposed_warn, proposed_error);
+      if(!validation.ok)
+      {
+        result.successful = false;
+        result.reason = validation.reason;
+        return result;
+      }
+      resend_giveup_warn_rate_per_s_ = proposed_warn;
+      resend_giveup_error_rate_per_s_ = proposed_error;
+      if(warn_changed)
+        RCLCPP_INFO_STREAM(get_logger(),
+          "resend_giveup_warn_rate_per_s updated to "
+          << resend_giveup_warn_rate_per_s_ << "/s");
+      if(error_changed)
+        RCLCPP_INFO_STREAM(get_logger(),
+          "resend_giveup_error_rate_per_s updated to "
+          << resend_giveup_error_rate_per_s_ << "/s");
       return result;
     });
 
@@ -1713,7 +1737,11 @@ void UDPBridge::diagnoseRemoteGiveups(const std::string& remote_name,
   stat.add("remote", remote_name);
   stat.add("give_ups_total", diag.total);
   stat.add("give_up_rate_per_s", diag.rate_per_s);
-  stat.add("window_s", elapsed_s);
+  // Clamp the published window to >= 0 so a backward clock jump
+  // (NTP correction, sim-time rewind) doesn't surface a negative
+  // window_s. computeGiveupDiagnostic already treats elapsed_s <= 0
+  // as zero-rate / OK, so this just keeps the KeyValue consistent.
+  stat.add("window_s", std::max(0.0, elapsed_s));
   stat.add("warn_threshold_per_s", warn_thresh);
   stat.add("error_threshold_per_s", error_thresh);
 

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -47,6 +47,8 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <poll.h>
+#include <iomanip>
+#include <sstream>
 #include <unordered_set>
 
 #include "udp_bridge_interfaces/msg/remote_subscribe_internal.hpp"
@@ -139,8 +141,10 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
 
   // Resend give-up rate thresholds (issue #22). Defaults calibrated
   // against the 2026-05-19 BizzyBoat storm (~3.9/s steady, ~700/s
-  // burst): steady fires WARN, burst fires ERROR. Tunable via
-  // deployment YAML without a rebuild.
+  // burst): steady fires WARN, burst fires ERROR. Live-tunable: the
+  // OnSetParameters callback below propagates `ros2 param set` to the
+  // cached members under remote_nodes_mutex_, so operators can adjust
+  // mid-storm without a reconfigure cycle.
   declare_parameter("resend_giveup_warn_rate_per_s", resend_giveup_warn_rate_per_s_);
   declare_parameter("resend_giveup_error_rate_per_s", resend_giveup_error_rate_per_s_);
   resend_giveup_warn_rate_per_s_ = get_parameter("resend_giveup_warn_rate_per_s").as_double();
@@ -148,6 +152,52 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
   RCLCPP_INFO_STREAM(get_logger(),
     "resend_giveup thresholds: warn=" << resend_giveup_warn_rate_per_s_
     << "/s, error=" << resend_giveup_error_rate_per_s_ << "/s");
+
+  on_set_parameters_handle_ = add_on_set_parameters_callback(
+    [this](const std::vector<rclcpp::Parameter>& params)
+        -> rcl_interfaces::msg::SetParametersResult
+    {
+      rcl_interfaces::msg::SetParametersResult result;
+      result.successful = true;
+      // Validate first so we can reject the whole batch atomically.
+      // Negative thresholds would never fire (rate is always >= 0)
+      // and indicate operator error rather than intent.
+      for(const auto& p: params)
+      {
+        if(p.get_name() == "resend_giveup_warn_rate_per_s" ||
+           p.get_name() == "resend_giveup_error_rate_per_s")
+        {
+          if(p.as_double() < 0.0)
+          {
+            result.successful = false;
+            result.reason = p.get_name() + " must be >= 0; got "
+              + std::to_string(p.as_double());
+            return result;
+          }
+        }
+      }
+      // Apply under the same lock the reader takes — keeps a torn
+      // read of the two threshold fields impossible.
+      std::lock_guard<std::mutex> lock(remote_nodes_mutex_);
+      for(const auto& p: params)
+      {
+        if(p.get_name() == "resend_giveup_warn_rate_per_s")
+        {
+          resend_giveup_warn_rate_per_s_ = p.as_double();
+          RCLCPP_INFO_STREAM(get_logger(),
+            "resend_giveup_warn_rate_per_s updated to "
+            << resend_giveup_warn_rate_per_s_ << "/s");
+        }
+        else if(p.get_name() == "resend_giveup_error_rate_per_s")
+        {
+          resend_giveup_error_rate_per_s_ = p.as_double();
+          RCLCPP_INFO_STREAM(get_logger(),
+            "resend_giveup_error_rate_per_s updated to "
+            << resend_giveup_error_rate_per_s_ << "/s");
+        }
+      }
+      return result;
+    });
 
   //maximum_packet_size_subscriber_ = ros::NodeHandle("~").subscribe("maximum_packet_size", 1, &UDPBridge::maximumPacketSizeCallback, this);
 
@@ -375,16 +425,19 @@ UDPBridge::CallbackReturn UDPBridge::on_cleanup(const rclcpp_lifecycle::State & 
   diagnostic_timer_.reset();
   diagnostic_updater_.reset();
   diagnostic_task_names_.clear();
+  // Drop the parameter-change callback handle so a subsequent
+  // on_configure cycle starts fresh; otherwise the previous handle
+  // would still be live and a duplicate would accumulate.
+  on_set_parameters_handle_.reset();
   // Per-remote diagnostic state: also clear, so an
   // activate→deactivate→activate cycle starts from a known baseline
-  // rather than carrying stale last_giveup_publish_time_ values that
-  // would compute a huge "elapsed" on the next publish. Guarded by
-  // remote_nodes_mutex_ per the lifecycle-state contract for these
-  // maps (declaration in udp_bridge.h).
+  // rather than carrying stale GiveupRateState entries that would
+  // compute a huge "elapsed" on the next publish. Guarded by
+  // remote_nodes_mutex_ per the lifecycle-state contract for this
+  // map (declaration in udp_bridge.h).
   {
     std::lock_guard<std::mutex> lock(remote_nodes_mutex_);
-    last_giveup_count_.clear();
-    last_giveup_publish_time_.clear();
+    giveup_rate_state_.clear();
   }
   return LifecycleNode::on_cleanup(state);
 }
@@ -1619,17 +1672,22 @@ void UDPBridge::diagnoseConnection(const std::string& remote_name,
 void UDPBridge::diagnoseRemoteGiveups(const std::string& remote_name,
                                       diagnostic_updater::DiagnosticStatusWrapper& stat)
 {
-  // Snapshot the remote pointer + take the give-up counter + read AND
-  // update the last_* maps all under remote_nodes_mutex_. The lock is
-  // brief — the counter read takes RemoteNode::state_mutex_ internally
-  // (lock-friendly per the comment at udp_bridge.cpp:1271) and the map
-  // ops are short integer/timestamp shuffles. STALE return mirrors
-  // diagnoseConnection() at line 1543 for the same race condition
-  // (remote removed between task registration and callback firing).
+  // Snapshot the remote pointer + the give-up counter + step the
+  // per-remote rate state + sample the thresholds all under
+  // remote_nodes_mutex_. The lock is brief — the counter read takes
+  // RemoteNode::state_mutex_ internally (lock-friendly per the
+  // comment at udp_bridge.cpp:1271) and the state-step is a tiny
+  // struct copy + compute. Sampling the thresholds under the same
+  // lock the OnSetParameters callback takes pins them against
+  // mid-callback runtime changes from `ros2 param set`. STALE return
+  // mirrors diagnoseConnection() at line 1543 for the same race
+  // condition (remote removed between task registration and
+  // diagnostic callback firing).
   rclcpp::Time now_time = now();
-  uint32_t current_count = 0;
+  GiveupDiagnostic diag;
   double elapsed_s = 0.0;
-  uint32_t prev_count = 0;
+  double warn_thresh = 0.0;
+  double error_thresh = 0.0;
   {
     std::lock_guard<std::mutex> lock(remote_nodes_mutex_);
     auto remote_it = remote_nodes_.find(remote_name);
@@ -1638,43 +1696,40 @@ void UDPBridge::diagnoseRemoteGiveups(const std::string& remote_name,
       stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "remote not registered");
       return;
     }
-    current_count = remote_it->second->resendGiveupCount();
-
-    auto last_count_it = last_giveup_count_.find(remote_name);
-    auto last_time_it = last_giveup_publish_time_.find(remote_name);
-    if(last_count_it != last_giveup_count_.end() &&
-       last_time_it != last_giveup_publish_time_.end())
-    {
-      prev_count = last_count_it->second;
-      elapsed_s = (now_time - last_time_it->second).seconds();
-    }
-    // First call (no prior entry): prev_count=0, elapsed_s=0 — the
-    // free function's zero-elapsed branch returns rate=0/OK without
-    // dividing. Update the maps before releasing the lock so the
-    // next call has a baseline.
-    last_giveup_count_[remote_name] = current_count;
-    last_giveup_publish_time_[remote_name] = now_time;
+    uint32_t current_count = remote_it->second->resendGiveupCount();
+    warn_thresh = resend_giveup_warn_rate_per_s_;
+    error_thresh = resend_giveup_error_rate_per_s_;
+    // operator[] default-constructs a fresh GiveupRateState (with
+    // has_previous=false) if this is the first call for remote_name,
+    // matching stepGiveupDiagnostic's first-call contract. Capture
+    // the elapsed window from the state's prior timestamp before the
+    // step writes the new sample back.
+    GiveupRateState& state = giveup_rate_state_[remote_name];
+    if(state.has_previous)
+      elapsed_s = (now_time - state.last_publish_time).seconds();
+    diag = stepGiveupDiagnostic(state, current_count, now_time, warn_thresh, error_thresh);
   }
-
-  GiveupDiagnostic diag = computeGiveupDiagnostic(
-      prev_count, current_count, elapsed_s,
-      resend_giveup_warn_rate_per_s_, resend_giveup_error_rate_per_s_);
 
   stat.add("remote", remote_name);
   stat.add("give_ups_total", diag.total);
   stat.add("give_up_rate_per_s", diag.rate_per_s);
   stat.add("window_s", elapsed_s);
-  stat.add("warn_threshold_per_s", resend_giveup_warn_rate_per_s_);
-  stat.add("error_threshold_per_s", resend_giveup_error_rate_per_s_);
+  stat.add("warn_threshold_per_s", warn_thresh);
+  stat.add("error_threshold_per_s", error_thresh);
 
-  std::string summary;
+  // Two-decimal formatting keeps the summary string operator-friendly
+  // in aggregator UIs; std::to_string(double) defaults to 6 fractional
+  // digits which is noisy ("5.000000/s exceeds warn threshold"). The
+  // structured KeyValues above still carry the raw doubles.
+  std::ostringstream summary;
+  summary << std::fixed << std::setprecision(2);
   if(diag.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR)
-    summary = "give-up rate " + std::to_string(diag.rate_per_s) + "/s exceeds error threshold";
+    summary << "give-up rate " << diag.rate_per_s << "/s exceeds error threshold";
   else if(diag.level == diagnostic_msgs::msg::DiagnosticStatus::WARN)
-    summary = "give-up rate " + std::to_string(diag.rate_per_s) + "/s exceeds warn threshold";
+    summary << "give-up rate " << diag.rate_per_s << "/s exceeds warn threshold";
   else
-    summary = "give-up rate " + std::to_string(diag.rate_per_s) + "/s (total " + std::to_string(diag.total) + ")";
-  stat.summary(diag.level, summary);
+    summary << "give-up rate " << diag.rate_per_s << "/s (total " << diag.total << ")";
+  stat.summary(diag.level, summary.str());
 }
 
 // void UDPBridge::maximumPacketSizeCallback(const std_msgs::Int32::ConstPtr& msg)

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -84,14 +84,14 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
   auto last_slash = name.rfind('/');
   if(last_slash != std::string::npos)
     name = name.substr(last_slash+1);
-  declare_parameter( "name", name);
+  declareIfMissing( "name", name);
   // This is the name of the UDPBridge node, not the ROS2 node name
   setName(get_parameter("name").as_string());
 
 
   RCLCPP_INFO_STREAM(get_logger(), "name: " << name_);
 
-  declare_parameter("port", port_);
+  declareIfMissing("port", port_);
   // ROS 2 parameters are int64. port_ is uint16_t; out-of-range values
   // would silently wrap and bind to an unintended port. Clamp + warn.
   {
@@ -112,7 +112,7 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
   }
   RCLCPP_INFO_STREAM(get_logger(), "port: " << port_);
 
-  declare_parameter("maximum_packet_size", max_packet_size_);
+  declareIfMissing("maximum_packet_size", max_packet_size_);
   // Bound the packet size to a sensible UDP range. Lower bound is the
   // minimum that still leaves room for a Packet header + a meaningful
   // payload after fragmentation; upper bound is the IPv4/UDP maximum.
@@ -146,8 +146,8 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
   // OnSetParameters callback below propagates `ros2 param set` to the
   // cached members under remote_nodes_mutex_, so operators can adjust
   // mid-storm without a reconfigure cycle.
-  declare_parameter("resend_giveup_warn_rate_per_s", resend_giveup_warn_rate_per_s_);
-  declare_parameter("resend_giveup_error_rate_per_s", resend_giveup_error_rate_per_s_);
+  declareIfMissing("resend_giveup_warn_rate_per_s", resend_giveup_warn_rate_per_s_);
+  declareIfMissing("resend_giveup_error_rate_per_s", resend_giveup_error_rate_per_s_);
   resend_giveup_warn_rate_per_s_ = get_parameter("resend_giveup_warn_rate_per_s").as_double();
   resend_giveup_error_rate_per_s_ = get_parameter("resend_giveup_error_rate_per_s").as_double();
   // Validate launch-time values. Launch-line overrides
@@ -310,7 +310,7 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
 
   bridge_info_publisher_ = create_publisher<BridgeInfo>(node_name+"/bridge_info", latching_qos);
 
-  declare_parameter("remotes_list", std::vector<std::string>());
+  declareIfMissing("remotes_list", std::vector<std::string>());
   auto remotes_list = get_parameter("remotes_list").as_string_array();
   for(auto remote_name: remotes_list)
   {
@@ -321,7 +321,7 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
 
 
     std::string connections_list_param = "remotes."+remote_name+".connections_list";
-    declare_parameter(connections_list_param, std::vector<std::string>());
+    declareIfMissing(connections_list_param, std::vector<std::string>());
     auto connections_list = get_parameter(connections_list_param).as_string_array();
     for(auto connection_name: connections_list)
     {
@@ -329,23 +329,23 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
       connection.connection_id = connection_name;
       
       std::string host_param = "remotes." + remote_name + ".connections." + connection_name + ".host";
-      declare_parameter(host_param, "");
+      declareIfMissing(host_param, "");
       connection.host = get_parameter(host_param).as_string();
 
       std::string port_param = "remotes." + remote_name + ".connections." + connection_name + ".port";
-      declare_parameter(port_param, 0);
+      declareIfMissing(port_param, 0);
       connection.port = get_parameter(port_param).as_int();
       
       std::string return_host_param = "remotes." + remote_name + ".connections." + connection_name + ".return_host";
-      declare_parameter(return_host_param, "");
+      declareIfMissing(return_host_param, "");
       connection.return_host = get_parameter(return_host_param).as_string();
 
       std::string return_port_param = "remotes." + remote_name + ".connections." + connection_name + ".return_port";
-      declare_parameter(return_port_param, 0);
+      declareIfMissing(return_port_param, 0);
       connection.return_port = get_parameter(return_port_param).as_int();
 
       std::string maximum_bytes_per_second_param = "remotes." + remote_name + ".connections." + connection_name + ".maximum_bytes_per_second";
-      declare_parameter(maximum_bytes_per_second_param, 0);
+      declareIfMissing(maximum_bytes_per_second_param, 0);
       int mbps = get_parameter(maximum_bytes_per_second_param).as_int();
       if(mbps > 0)
         connection.maximum_bytes_per_second = mbps;
@@ -354,37 +354,37 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
       remote_nodes_[remote_info.name]->update(remote_info);
 
       std::string topics_list_param = "remotes." + remote_name + ".connections." + connection_name + ".topics_list";
-      declare_parameter(topics_list_param, std::vector<std::string>());
+      declareIfMissing(topics_list_param, std::vector<std::string>());
       auto topics_list = get_parameter(topics_list_param).as_string_array();
       for(auto topic: topics_list)
       {
         std::string queue_size_param = "remotes." + remote_name + ".connections." + connection_name + ".topics." + topic + ".queue_size";
-        declare_parameter(queue_size_param, 10);
+        declareIfMissing(queue_size_param, 10);
         int queue_size = get_parameter(queue_size_param).as_int();
 
         std::string period_param = "remotes." + remote_name + ".connections." + connection_name + ".topics." + topic + ".period";
-        declare_parameter(period_param, 0.0);
+        declareIfMissing(period_param, 0.0);
         double period = get_parameter(period_param).as_double();
 
         std::string source_param = "remotes." + remote_name + ".connections." + connection_name + ".topics." + topic + ".source";
-        declare_parameter(source_param, topic);
+        declareIfMissing(source_param, topic);
         std::string source = get_parameter(source_param).as_string();
         source = get_node_base_interface()->resolve_topic_or_service_name(source, false, false);
 
         std::string destination_param = "remotes." + remote_name + ".connections." + connection_name + ".topics." + topic + ".destination";
-        declare_parameter(destination_param, source);
+        declareIfMissing(destination_param, source);
         auto destination = get_parameter(destination_param).as_string();
 
         std::string reliability_param = "remotes." + remote_name + ".connections." + connection_name + ".topics." + topic + ".reliability";
-        declare_parameter(reliability_param, std::string());
+        declareIfMissing(reliability_param, std::string());
         std::string reliability = get_parameter(reliability_param).as_string();
 
         std::string durability_param = "remotes." + remote_name + ".connections." + connection_name + ".topics." + topic + ".durability";
-        declare_parameter(durability_param, std::string());
+        declareIfMissing(durability_param, std::string());
         std::string durability = get_parameter(durability_param).as_string();
 
         std::string history_depth_param = "remotes." + remote_name + ".connections." + connection_name + ".topics." + topic + ".history_depth";
-        declare_parameter(history_depth_param, 0);
+        declareIfMissing(history_depth_param, 0);
         // ROS 2 parameters are int64; an unchecked static_cast<uint32_t>
         // of a negative or out-of-range value wraps to a billions-large
         // depth and triggers a huge KEEP_LAST allocation in the rmw
@@ -1698,15 +1698,16 @@ void UDPBridge::diagnoseRemoteGiveups(const std::string& remote_name,
 {
   // Snapshot the remote pointer + the give-up counter + step the
   // per-remote rate state + sample the thresholds all under
-  // remote_nodes_mutex_. The lock is brief — the counter read takes
-  // RemoteNode::state_mutex_ internally (lock-friendly per the
-  // comment at udp_bridge.cpp:1271) and the state-step is a tiny
-  // struct copy + compute. Sampling the thresholds under the same
-  // lock the OnSetParameters callback takes pins them against
-  // mid-callback runtime changes from `ros2 param set`. STALE return
-  // mirrors diagnoseConnection() at line 1543 for the same race
-  // condition (remote removed between task registration and
-  // diagnostic callback firing).
+  // remote_nodes_mutex_. The lock is brief — the counter read
+  // (RemoteNode::resendGiveupCount() in remote_node.cpp) takes only
+  // the recursive RemoteNode::state_mutex_ and does not re-acquire
+  // remote_nodes_mutex_, so it is lock-friendly here; the state-step
+  // is a tiny struct copy + compute. Sampling the thresholds under
+  // the same lock the OnSetParameters callback takes pins them
+  // against mid-callback runtime changes from `ros2 param set`. The
+  // STALE return mirrors diagnoseConnection() above: the remote may
+  // have been removed between task registration and the diagnostic
+  // callback firing.
   rclcpp::Time now_time = now();
   GiveupDiagnostic diag;
   double elapsed_s = 0.0;

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -56,6 +56,7 @@
 #include "udp_bridge_interfaces/msg/resend_request.hpp"
 #include "udp_bridge/remote_node.h"
 #include "udp_bridge/resend_constants.h"
+#include "udp_bridge/giveup_diagnostic.h"
 #include "udp_bridge/types.h"
 #include "udp_bridge/utilities.h"
 #include "lifecycle_msgs/msg/state.hpp"
@@ -135,6 +136,18 @@ UDPBridge::CallbackReturn UDPBridge::on_configure(const rclcpp_lifecycle::State 
     max_packet_size_ = static_cast<int>(configured_packet_size);
   }
   RCLCPP_INFO_STREAM(get_logger(), "maximum_packet_size: " << max_packet_size_);
+
+  // Resend give-up rate thresholds (issue #22). Defaults calibrated
+  // against the 2026-05-19 BizzyBoat storm (~3.9/s steady, ~700/s
+  // burst): steady fires WARN, burst fires ERROR. Tunable via
+  // deployment YAML without a rebuild.
+  declare_parameter("resend_giveup_warn_rate_per_s", resend_giveup_warn_rate_per_s_);
+  declare_parameter("resend_giveup_error_rate_per_s", resend_giveup_error_rate_per_s_);
+  resend_giveup_warn_rate_per_s_ = get_parameter("resend_giveup_warn_rate_per_s").as_double();
+  resend_giveup_error_rate_per_s_ = get_parameter("resend_giveup_error_rate_per_s").as_double();
+  RCLCPP_INFO_STREAM(get_logger(),
+    "resend_giveup thresholds: warn=" << resend_giveup_warn_rate_per_s_
+    << "/s, error=" << resend_giveup_error_rate_per_s_ << "/s");
 
   //maximum_packet_size_subscriber_ = ros::NodeHandle("~").subscribe("maximum_packet_size", 1, &UDPBridge::maximumPacketSizeCallback, this);
 
@@ -362,6 +375,17 @@ UDPBridge::CallbackReturn UDPBridge::on_cleanup(const rclcpp_lifecycle::State & 
   diagnostic_timer_.reset();
   diagnostic_updater_.reset();
   diagnostic_task_names_.clear();
+  // Per-remote diagnostic state: also clear, so an
+  // activate→deactivate→activate cycle starts from a known baseline
+  // rather than carrying stale last_giveup_publish_time_ values that
+  // would compute a huge "elapsed" on the next publish. Guarded by
+  // remote_nodes_mutex_ per the lifecycle-state contract for these
+  // maps (declaration in udp_bridge.h).
+  {
+    std::lock_guard<std::mutex> lock(remote_nodes_mutex_);
+    last_giveup_count_.clear();
+    last_giveup_publish_time_.clear();
+  }
   return LifecycleNode::on_cleanup(state);
 }
 
@@ -1473,16 +1497,18 @@ void UDPBridge::syncDiagnosticTasks()
 {
   if(!diagnostic_updater_)
     return;
-  // Snapshot (remote_name, connection_id) pairs under the lock; the
-  // diagnostic_updater_->add call captures by value so the registered task
-  // does not need to outlive the lock.
+  // Snapshot (remote_name, connection_id) pairs and remote names under
+  // the lock; the diagnostic_updater_->add call captures by value so
+  // registered tasks don't need to outlive the lock.
   std::vector<std::pair<std::string, std::string>> remote_connection_pairs;
+  std::vector<std::string> remote_names;
   {
     std::lock_guard<std::mutex> lock(remote_nodes_mutex_);
     for(auto& remote_entry: remote_nodes_)
     {
       if(!remote_entry.second)
         continue;
+      remote_names.push_back(remote_entry.first);
       for(auto& connection: remote_entry.second->connections())
       {
         if(!connection)
@@ -1502,6 +1528,24 @@ void UDPBridge::syncDiagnosticTasks()
       [this, remote_name, connection_id](diagnostic_updater::DiagnosticStatusWrapper& stat)
       {
         diagnoseConnection(remote_name, connection_id, stat);
+      });
+    diagnostic_task_names_.insert(task_name);
+  }
+  // Per-remote resend-give-up diagnostic (issue #22). Task name format
+  // mirrors the per-connection convention above so the aggregator
+  // groups them next to the related connection statuses. The
+  // diagnostic_task_names_ gate prevents double-add if a remote of the
+  // same name is removed and re-added in the same activate cycle —
+  // diagnostic_updater::Updater has no per-task remove() API.
+  for(const auto& remote_name: remote_names)
+  {
+    std::string task_name = "udp_bridge " + name_ + ": " + remote_name + ": resend give-ups";
+    if(diagnostic_task_names_.count(task_name))
+      continue;
+    diagnostic_updater_->add(task_name,
+      [this, remote_name](diagnostic_updater::DiagnosticStatusWrapper& stat)
+      {
+        diagnoseRemoteGiveups(remote_name, stat);
       });
     diagnostic_task_names_.insert(task_name);
   }
@@ -1570,6 +1614,67 @@ void UDPBridge::diagnoseConnection(const std::string& remote_name,
   {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, summary);
   }
+}
+
+void UDPBridge::diagnoseRemoteGiveups(const std::string& remote_name,
+                                      diagnostic_updater::DiagnosticStatusWrapper& stat)
+{
+  // Snapshot the remote pointer + take the give-up counter + read AND
+  // update the last_* maps all under remote_nodes_mutex_. The lock is
+  // brief — the counter read takes RemoteNode::state_mutex_ internally
+  // (lock-friendly per the comment at udp_bridge.cpp:1271) and the map
+  // ops are short integer/timestamp shuffles. STALE return mirrors
+  // diagnoseConnection() at line 1543 for the same race condition
+  // (remote removed between task registration and callback firing).
+  rclcpp::Time now_time = now();
+  uint32_t current_count = 0;
+  double elapsed_s = 0.0;
+  uint32_t prev_count = 0;
+  {
+    std::lock_guard<std::mutex> lock(remote_nodes_mutex_);
+    auto remote_it = remote_nodes_.find(remote_name);
+    if(remote_it == remote_nodes_.end() || !remote_it->second)
+    {
+      stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "remote not registered");
+      return;
+    }
+    current_count = remote_it->second->resendGiveupCount();
+
+    auto last_count_it = last_giveup_count_.find(remote_name);
+    auto last_time_it = last_giveup_publish_time_.find(remote_name);
+    if(last_count_it != last_giveup_count_.end() &&
+       last_time_it != last_giveup_publish_time_.end())
+    {
+      prev_count = last_count_it->second;
+      elapsed_s = (now_time - last_time_it->second).seconds();
+    }
+    // First call (no prior entry): prev_count=0, elapsed_s=0 — the
+    // free function's zero-elapsed branch returns rate=0/OK without
+    // dividing. Update the maps before releasing the lock so the
+    // next call has a baseline.
+    last_giveup_count_[remote_name] = current_count;
+    last_giveup_publish_time_[remote_name] = now_time;
+  }
+
+  GiveupDiagnostic diag = computeGiveupDiagnostic(
+      prev_count, current_count, elapsed_s,
+      resend_giveup_warn_rate_per_s_, resend_giveup_error_rate_per_s_);
+
+  stat.add("remote", remote_name);
+  stat.add("give_ups_total", diag.total);
+  stat.add("give_up_rate_per_s", diag.rate_per_s);
+  stat.add("window_s", elapsed_s);
+  stat.add("warn_threshold_per_s", resend_giveup_warn_rate_per_s_);
+  stat.add("error_threshold_per_s", resend_giveup_error_rate_per_s_);
+
+  std::string summary;
+  if(diag.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR)
+    summary = "give-up rate " + std::to_string(diag.rate_per_s) + "/s exceeds error threshold";
+  else if(diag.level == diagnostic_msgs::msg::DiagnosticStatus::WARN)
+    summary = "give-up rate " + std::to_string(diag.rate_per_s) + "/s exceeds warn threshold";
+  else
+    summary = "give-up rate " + std::to_string(diag.rate_per_s) + "/s (total " + std::to_string(diag.total) + ")";
+  stat.summary(diag.level, summary);
 }
 
 // void UDPBridge::maximumPacketSizeCallback(const std_msgs::Int32::ConstPtr& msg)

--- a/udp_bridge/test/test_giveup_diagnostic.cpp
+++ b/udp_bridge/test/test_giveup_diagnostic.cpp
@@ -20,6 +20,9 @@
 
 #include "udp_bridge/giveup_diagnostic.h"
 
+#include <cmath>
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
@@ -32,6 +35,7 @@ using udp_bridge::computeGiveupDiagnostic;
 using udp_bridge::GiveupDiagnostic;
 using udp_bridge::GiveupRateState;
 using udp_bridge::stepGiveupDiagnostic;
+using udp_bridge::validateGiveupThresholds;
 using DS = diagnostic_msgs::msg::DiagnosticStatus;
 
 constexpr double kWarn = 5.0;
@@ -276,4 +280,87 @@ TEST(GiveupRateState, ThresholdChangeTakesEffectOnNextStep)
   GiveupDiagnostic d2 = stepGiveupDiagnostic(state, 108, t_at(12.0), /*warn=*/1.0, kError);
   EXPECT_EQ(d2.level, DS::WARN);
   EXPECT_DOUBLE_EQ(d2.rate_per_s, 4.0);
+}
+
+// ----- validateGiveupThresholds -----
+
+TEST(GiveupThresholdValidation, DefaultPairIsAccepted)
+{
+  // The calibrated 5/50 defaults must validate cleanly — otherwise the
+  // on_configure path would fail every launch.
+  auto v = validateGiveupThresholds(5.0, 50.0);
+  EXPECT_TRUE(v.ok);
+  EXPECT_TRUE(v.reason.empty());
+}
+
+TEST(GiveupThresholdValidation, EqualWarnAndErrorIsAccepted)
+{
+  // warn == error collapses the WARN band to a single point, but it is
+  // not invalid; an operator may want only OK/ERROR transitions.
+  auto v = validateGiveupThresholds(10.0, 10.0);
+  EXPECT_TRUE(v.ok);
+}
+
+TEST(GiveupThresholdValidation, ZeroThresholdsAreAccepted)
+{
+  // 0/0 means every nonzero rate fires ERROR. Pathological but valid;
+  // not the validator's job to second-guess intent.
+  auto v = validateGiveupThresholds(0.0, 0.0);
+  EXPECT_TRUE(v.ok);
+}
+
+TEST(GiveupThresholdValidation, NegativeWarnIsRejected)
+{
+  auto v = validateGiveupThresholds(-1.0, 50.0);
+  EXPECT_FALSE(v.ok);
+  EXPECT_NE(v.reason.find("resend_giveup_warn_rate_per_s"), std::string::npos);
+  EXPECT_NE(v.reason.find(">= 0"), std::string::npos);
+}
+
+TEST(GiveupThresholdValidation, NegativeErrorIsRejected)
+{
+  auto v = validateGiveupThresholds(5.0, -10.0);
+  EXPECT_FALSE(v.ok);
+  EXPECT_NE(v.reason.find("resend_giveup_error_rate_per_s"), std::string::npos);
+  EXPECT_NE(v.reason.find(">= 0"), std::string::npos);
+}
+
+TEST(GiveupThresholdValidation, NanWarnIsRejected)
+{
+  // NaN comparisons return false, so a NaN threshold silently disables
+  // the diagnostic. Must be rejected with an operator-actionable reason.
+  auto v = validateGiveupThresholds(std::numeric_limits<double>::quiet_NaN(), 50.0);
+  EXPECT_FALSE(v.ok);
+  EXPECT_NE(v.reason.find("resend_giveup_warn_rate_per_s"), std::string::npos);
+  EXPECT_NE(v.reason.find("finite"), std::string::npos);
+}
+
+TEST(GiveupThresholdValidation, NanErrorIsRejected)
+{
+  auto v = validateGiveupThresholds(5.0, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_FALSE(v.ok);
+  EXPECT_NE(v.reason.find("resend_giveup_error_rate_per_s"), std::string::npos);
+  EXPECT_NE(v.reason.find("finite"), std::string::npos);
+}
+
+TEST(GiveupThresholdValidation, PositiveInfinityIsRejected)
+{
+  // Infinity is finite-via-comparison but isfinite() rejects it. An
+  // infinite threshold could never be exceeded, so the diagnostic would
+  // never fire — same failure mode as NaN, different IEEE bit pattern.
+  auto v = validateGiveupThresholds(5.0, std::numeric_limits<double>::infinity());
+  EXPECT_FALSE(v.ok);
+  EXPECT_NE(v.reason.find("finite"), std::string::npos);
+}
+
+TEST(GiveupThresholdValidation, InvertedPairIsRejected)
+{
+  // warn > error would make the WARN band empty: rates above warn would
+  // also be above error and fire ERROR, never WARN. Operator-error
+  // signal — caught with both values printed so the operator can fix it.
+  auto v = validateGiveupThresholds(/*warn=*/50.0, /*error=*/5.0);
+  EXPECT_FALSE(v.ok);
+  EXPECT_NE(v.reason.find("resend_giveup_warn_rate_per_s"), std::string::npos);
+  EXPECT_NE(v.reason.find("resend_giveup_error_rate_per_s"), std::string::npos);
+  EXPECT_NE(v.reason.find("<="), std::string::npos);
 }

--- a/udp_bridge/test/test_giveup_diagnostic.cpp
+++ b/udp_bridge/test/test_giveup_diagnostic.cpp
@@ -1,30 +1,47 @@
 // Tests for the resend-give-up rate / threshold computation (#22).
 //
-// These tests exercise the free function `computeGiveupDiagnostic`
-// directly — no UDPBridge instance, no rclcpp executor, no clock
-// fixture. The time-dependence is moved out of the function into the
-// caller (elapsed_s is a parameter), so tests are deterministic and
-// instantaneous.
+// Two layers of tests live here:
 //
-// Wrapper-side behavior (per-remote map state, lock discipline,
-// integration with diagnostic_updater) is intentionally NOT covered
-// here — see issue #22 plan §4.
+// 1. `computeGiveupDiagnostic` (pure free function) — exhaustive
+//    arithmetic and threshold-boundary coverage. No state, no clock.
+//
+// 2. `stepGiveupDiagnostic` (stateful helper used by
+//    UDPBridge::diagnoseRemoteGiveups) — wrapper-side behavior:
+//    first-call initialization, sequential state-update ordering,
+//    counter reset across calls, multi-state independence. These
+//    tests cover the map-update-ordering invariant that the
+//    UDPBridge wrapper depends on without needing to bring up a
+//    real UDPBridge node (which would require sockets / executors).
+//
+// Mutex discipline of the UDPBridge wrapper is not directly testable
+// here (no thread safety harness); the helper's pure-by-design
+// semantics mean the only way the wrapper can go wrong is by failing
+// to hold the lock — caught by code review, not unit test.
 
 #include "udp_bridge/giveup_diagnostic.h"
 
 #include <gtest/gtest.h>
 
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "rclcpp/time.hpp"
 
 namespace
 {
 
 using udp_bridge::computeGiveupDiagnostic;
 using udp_bridge::GiveupDiagnostic;
+using udp_bridge::GiveupRateState;
+using udp_bridge::stepGiveupDiagnostic;
 using DS = diagnostic_msgs::msg::DiagnosticStatus;
 
 constexpr double kWarn = 5.0;
 constexpr double kError = 50.0;
+constexpr rcl_clock_type_t kClock = RCL_ROS_TIME;
+
+rclcpp::Time t_at(double seconds)
+{
+  return rclcpp::Time(static_cast<int64_t>(seconds * 1e9), kClock);
+}
 
 }  // namespace
 
@@ -134,4 +151,129 @@ TEST(GiveupDiagnostic, CustomThresholdsRespected)
   GiveupDiagnostic d = computeGiveupDiagnostic(0, 2, 1.0, /*warn=*/1.0, /*error=*/10.0);
   EXPECT_EQ(d.level, DS::WARN);
   EXPECT_DOUBLE_EQ(d.rate_per_s, 2.0);
+}
+
+// ----- stepGiveupDiagnostic (wrapper-side state) -----
+
+// First call: state starts with has_previous=false. Must NOT compute
+// a rate from the default-constructed last_publish_time (which is
+// epoch=0 — the difference against a real `now` would be huge). Rate
+// must be 0/OK regardless of current_count. State is then populated
+// so the second call has a baseline.
+TEST(GiveupRateState, FirstCallReportsZeroRateAndPopulatesState)
+{
+  GiveupRateState state;
+  EXPECT_FALSE(state.has_previous);
+
+  GiveupDiagnostic d = stepGiveupDiagnostic(state, 42, t_at(100.0), kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 0.0);
+  EXPECT_EQ(d.total, 42u);
+
+  EXPECT_TRUE(state.has_previous);
+  EXPECT_EQ(state.last_count, 42u);
+  EXPECT_DOUBLE_EQ(state.last_publish_time.seconds(), 100.0);
+}
+
+// Two-call sequence: second call sees the first's count + time as
+// `prev`. This pins the map-update-ordering invariant — if
+// stepGiveupDiagnostic wrote the new sample before reading the
+// previous, this test would fail with rate=0 instead of rate=4.
+TEST(GiveupRateState, SecondCallComputesRateFromFirstCallBaseline)
+{
+  GiveupRateState state;
+  stepGiveupDiagnostic(state, 100, t_at(10.0), kWarn, kError);
+
+  GiveupDiagnostic d = stepGiveupDiagnostic(state, 104, t_at(11.0), kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 4.0);
+  EXPECT_EQ(d.total, 104u);
+
+  EXPECT_EQ(state.last_count, 104u);
+  EXPECT_DOUBLE_EQ(state.last_publish_time.seconds(), 11.0);
+}
+
+// Counter reset across calls (sender restart per #21). The second
+// call sees current < prev. Wrapper must NOT underflow the subtract;
+// computeGiveupDiagnostic's reset branch returns rate=0/OK, and the
+// state must update to the new (smaller) count so the third call
+// continues from the new baseline.
+TEST(GiveupRateState, CounterResetAcrossCallsHandledByWrapper)
+{
+  GiveupRateState state;
+  stepGiveupDiagnostic(state, 1'000'000, t_at(10.0), kWarn, kError);
+
+  GiveupDiagnostic d = stepGiveupDiagnostic(state, 5, t_at(11.0), kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 0.0);
+  EXPECT_EQ(d.total, 5u);
+  EXPECT_EQ(state.last_count, 5u);
+
+  // Third call, post-reset: rate computed from the new baseline.
+  GiveupDiagnostic d2 = stepGiveupDiagnostic(state, 8, t_at(12.0), kWarn, kError);
+  EXPECT_EQ(d2.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d2.rate_per_s, 3.0);
+}
+
+// Same-remote queried twice within the same `now()` tick: elapsed=0,
+// rate=0/OK regardless of count delta. State updates so subsequent
+// calls with real elapsed see the latest count as prev.
+TEST(GiveupRateState, ZeroElapsedBetweenStepsReturnsZeroRate)
+{
+  GiveupRateState state;
+  stepGiveupDiagnostic(state, 100, t_at(10.0), kWarn, kError);
+
+  GiveupDiagnostic d = stepGiveupDiagnostic(state, 200, t_at(10.0), kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 0.0);
+  EXPECT_EQ(d.total, 200u);
+
+  // Third call moves time forward; rate computed from the second-call
+  // count (state was correctly updated even when rate was suppressed).
+  GiveupDiagnostic d2 = stepGiveupDiagnostic(state, 210, t_at(11.0), kWarn, kError);
+  EXPECT_EQ(d2.level, DS::WARN);
+  EXPECT_DOUBLE_EQ(d2.rate_per_s, 10.0);
+}
+
+// Two independent states track separately. This is the wrapper's
+// multi-remote independence story: each remote has its own
+// GiveupRateState in the giveup_rate_state_ map, so stepping one does
+// not perturb the other. (UDPBridge::diagnoseRemoteGiveups indexes
+// the map by remote_name to get the per-remote state; this test
+// exercises the underlying separation invariant.)
+TEST(GiveupRateState, TwoIndependentStatesDoNotInterfere)
+{
+  GiveupRateState alpha;
+  GiveupRateState beta;
+
+  stepGiveupDiagnostic(alpha, 100, t_at(10.0), kWarn, kError);
+  stepGiveupDiagnostic(beta, 500, t_at(10.0), kWarn, kError);
+
+  GiveupDiagnostic da = stepGiveupDiagnostic(alpha, 104, t_at(11.0), kWarn, kError);
+  GiveupDiagnostic db = stepGiveupDiagnostic(beta, 1000, t_at(11.0), kWarn, kError);
+
+  EXPECT_DOUBLE_EQ(da.rate_per_s, 4.0);    // alpha rate over its own window
+  EXPECT_DOUBLE_EQ(db.rate_per_s, 500.0);  // beta rate, far above ERROR
+  EXPECT_EQ(da.level, DS::OK);
+  EXPECT_EQ(db.level, DS::ERROR);
+}
+
+// Wrapper-side threshold change: if the caller passes new thresholds
+// on a subsequent step (simulating an OnSetParametersCallback live
+// update), the new thresholds take effect immediately — the state
+// struct holds no copy of the thresholds.
+TEST(GiveupRateState, ThresholdChangeTakesEffectOnNextStep)
+{
+  GiveupRateState state;
+  stepGiveupDiagnostic(state, 100, t_at(10.0), kWarn, kError);
+
+  // First call at the original 5/50 thresholds: rate=4 -> OK.
+  GiveupDiagnostic d1 = stepGiveupDiagnostic(state, 104, t_at(11.0), kWarn, kError);
+  EXPECT_EQ(d1.level, DS::OK);
+
+  // Operator tightens WARN to 1/s mid-session; next call fires WARN
+  // immediately at the same rate=4.
+  GiveupDiagnostic d2 = stepGiveupDiagnostic(state, 108, t_at(12.0), /*warn=*/1.0, kError);
+  EXPECT_EQ(d2.level, DS::WARN);
+  EXPECT_DOUBLE_EQ(d2.rate_per_s, 4.0);
 }

--- a/udp_bridge/test/test_giveup_diagnostic.cpp
+++ b/udp_bridge/test/test_giveup_diagnostic.cpp
@@ -1,0 +1,137 @@
+// Tests for the resend-give-up rate / threshold computation (#22).
+//
+// These tests exercise the free function `computeGiveupDiagnostic`
+// directly — no UDPBridge instance, no rclcpp executor, no clock
+// fixture. The time-dependence is moved out of the function into the
+// caller (elapsed_s is a parameter), so tests are deterministic and
+// instantaneous.
+//
+// Wrapper-side behavior (per-remote map state, lock discipline,
+// integration with diagnostic_updater) is intentionally NOT covered
+// here — see issue #22 plan §4.
+
+#include "udp_bridge/giveup_diagnostic.h"
+
+#include <gtest/gtest.h>
+
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+
+namespace
+{
+
+using udp_bridge::computeGiveupDiagnostic;
+using udp_bridge::GiveupDiagnostic;
+using DS = diagnostic_msgs::msg::DiagnosticStatus;
+
+constexpr double kWarn = 5.0;
+constexpr double kError = 50.0;
+
+}  // namespace
+
+TEST(GiveupDiagnostic, SteadyStateRateBelowWarnIsOk)
+{
+  // 4 give-ups over 1 second = 4/s, below the 5/s warn threshold.
+  GiveupDiagnostic d = computeGiveupDiagnostic(100, 104, 1.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 4.0);
+  EXPECT_EQ(d.total, 104u);
+}
+
+TEST(GiveupDiagnostic, RateAtWarnThresholdFiresWarn)
+{
+  // Exactly at the threshold — inclusive comparison fires WARN.
+  GiveupDiagnostic d = computeGiveupDiagnostic(0, 5, 1.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::WARN);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 5.0);
+}
+
+TEST(GiveupDiagnostic, RateAboveWarnBelowErrorFiresWarn)
+{
+  GiveupDiagnostic d = computeGiveupDiagnostic(0, 30, 1.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::WARN);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 30.0);
+}
+
+TEST(GiveupDiagnostic, RateAtErrorThresholdFiresError)
+{
+  GiveupDiagnostic d = computeGiveupDiagnostic(0, 50, 1.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::ERROR);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 50.0);
+}
+
+TEST(GiveupDiagnostic, RateFarAboveErrorFiresError)
+{
+  // 2026-05-19 deployment hit ~700/s burst.
+  GiveupDiagnostic d = computeGiveupDiagnostic(0, 700, 1.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::ERROR);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 700.0);
+}
+
+TEST(GiveupDiagnostic, FirstCallNoPriorState)
+{
+  // prev_count=0 paired with elapsed_s=0 represents the first call:
+  // there's no baseline so we cannot compute a rate yet. Must NOT
+  // divide; must return rate=0/OK and surface the current cumulative.
+  GiveupDiagnostic d = computeGiveupDiagnostic(0, 42, 0.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 0.0);
+  EXPECT_EQ(d.total, 42u);
+}
+
+TEST(GiveupDiagnostic, ZeroElapsedReturnsZeroRate)
+{
+  // Two ticks within the same sim-time `now()` (or any zero-elapsed
+  // window) must not divide by zero — return rate=0/OK regardless of
+  // the counter delta.
+  GiveupDiagnostic d = computeGiveupDiagnostic(100, 200, 0.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 0.0);
+  EXPECT_EQ(d.total, 200u);
+}
+
+TEST(GiveupDiagnostic, NegativeElapsedReturnsZeroRate)
+{
+  // Clock-jump backward (NTP correction, sim-time reset) must collapse
+  // to "no measurable rate" rather than emit a garbage negative rate.
+  GiveupDiagnostic d = computeGiveupDiagnostic(100, 105, -0.5, kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 0.0);
+}
+
+TEST(GiveupDiagnostic, CounterResetReturnsZeroRate)
+{
+  // Per #21, the give-up counter has been observed to rewind across a
+  // sender restart. `current < prev` must NOT compute as a negative
+  // rate (would underflow the uint32 subtract and emit a wildly large
+  // rate). Reset path: rate=0, level=OK, total reflects current.
+  GiveupDiagnostic d = computeGiveupDiagnostic(1'000'000, 5, 1.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 0.0);
+  EXPECT_EQ(d.total, 5u);
+}
+
+TEST(GiveupDiagnostic, LongWindowAveragesCorrectly)
+{
+  // 60 give-ups across a 60-second window = 1/s steady, below WARN.
+  GiveupDiagnostic d = computeGiveupDiagnostic(0, 60, 60.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 1.0);
+}
+
+TEST(GiveupDiagnostic, JustBelowWarnStaysOk)
+{
+  // 4.99/s — strictly less than the threshold, must NOT cross.
+  GiveupDiagnostic d = computeGiveupDiagnostic(0, 499, 100.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 4.99);
+}
+
+TEST(GiveupDiagnostic, CustomThresholdsRespected)
+{
+  // Tighter thresholds (e.g., a deployment that lowers WARN to 1/s
+  // per the deferred Open Question 2). Verify the function honors
+  // the caller's thresholds, not the calibrated defaults.
+  GiveupDiagnostic d = computeGiveupDiagnostic(0, 2, 1.0, /*warn=*/1.0, /*error=*/10.0);
+  EXPECT_EQ(d.level, DS::WARN);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 2.0);
+}

--- a/udp_bridge/test/test_giveup_diagnostic.cpp
+++ b/udp_bridge/test/test_giveup_diagnostic.cpp
@@ -131,6 +131,46 @@ TEST(GiveupDiagnostic, CounterResetReturnsZeroRate)
   EXPECT_EQ(d.total, 5u);
 }
 
+TEST(GiveupDiagnostic, NoActivityReturnsOk)
+{
+  // current == prev means no give-up events happened this window.
+  // Must short-circuit to OK regardless of threshold values — the
+  // diagnostic reports activity, not its absence.
+  GiveupDiagnostic d = computeGiveupDiagnostic(100, 100, 1.0, kWarn, kError);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 0.0);
+  EXPECT_EQ(d.total, 100u);
+}
+
+TEST(GiveupDiagnostic, ZeroDeltaWithZeroThresholdsStaysOk)
+{
+  // Regression for Copilot round-3 on PR #24: validateGiveupThresholds
+  // accepts 0/0, and without the no-activity short-circuit the `>=`
+  // comparison fires ERROR on every quiet tick (0.0 >= 0.0 is true).
+  // The no-activity branch must run before threshold comparison so a
+  // 0/0 pair behaves as "WARN/ERROR on any give-up activity, OK
+  // otherwise" rather than "permanently non-OK".
+  GiveupDiagnostic d = computeGiveupDiagnostic(
+      /*prev=*/5, /*current=*/5, /*elapsed=*/1.0,
+      /*warn=*/0.0, /*error=*/0.0);
+  EXPECT_EQ(d.level, DS::OK);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 0.0);
+  EXPECT_EQ(d.total, 5u);
+}
+
+TEST(GiveupDiagnostic, ZeroWarnFiresOnAnyActivity)
+{
+  // Companion to ZeroDeltaWithZeroThresholdsStaysOk: validates that
+  // warn=0 still means "WARN on any non-zero rate", not "WARN never".
+  // With current > prev and elapsed > 0, the threshold branch runs and
+  // a rate of 1/s is >= warn=0 → WARN (since 1 < error=10 → not ERROR).
+  GiveupDiagnostic d = computeGiveupDiagnostic(
+      /*prev=*/0, /*current=*/1, /*elapsed=*/1.0,
+      /*warn=*/0.0, /*error=*/10.0);
+  EXPECT_EQ(d.level, DS::WARN);
+  EXPECT_DOUBLE_EQ(d.rate_per_s, 1.0);
+}
+
 TEST(GiveupDiagnostic, LongWindowAveragesCorrectly)
 {
   // 60 give-ups across a 60-second window = 1/s steady, below WARN.
@@ -303,8 +343,13 @@ TEST(GiveupThresholdValidation, EqualWarnAndErrorIsAccepted)
 
 TEST(GiveupThresholdValidation, ZeroThresholdsAreAccepted)
 {
-  // 0/0 means every nonzero rate fires ERROR. Pathological but valid;
-  // not the validator's job to second-guess intent.
+  // 0/0 is a pathological-but-valid configuration: it means every
+  // give-up event fires ERROR (rate > 0 trips the `>= 0` comparison).
+  // The validator's job is range/relation checks, not intent guessing.
+  // Note: the diagnostic computation has a no-activity short-circuit
+  // (computeGiveupDiagnostic returns OK when current == prev) so a
+  // 0/0 pair doesn't make every quiet tick fire — see
+  // ZeroDeltaWithZeroThresholdsStaysOk below for the regression.
   auto v = validateGiveupThresholds(0.0, 0.0);
   EXPECT_TRUE(v.ok);
 }


### PR DESCRIPTION
Closes #22

# Plan: 'Giving up on resend' WARN log too loud — rate-limit or surface as DiagnosticStatus

## Issue

https://github.com/rolker/udp_bridge/issues/22

## Context

After [#13](https://github.com/rolker/udp_bridge/pull/13) added resend give-up tracking, the per-event WARN at `remote_node.cpp:329` fires at **~233/min average, hundreds-to-thousands/s burst** on any lossy link (verified against the 2026-05-19 BizzyBoat deployment: 27,992 WARN entries in ~2h). This pollutes `/rosout`, bloats bags by ~5.6 MB per deployment, and desensitizes operators to genuine WARNs. The give-up *behavior* is correct; the *severity* is the problem.

Issue owner's comment lays out the convergent design: demote the per-event log WARN → DEBUG, and publish a per-remote `DiagnosticStatus` with rate metric and threshold-based severity. Code exploration adds a refinement: udp_bridge already runs a `diagnostic_updater::Updater` (added at `udp_bridge.cpp:341`) and registers per-(remote, connection) diagnostic tasks. The new resend-give-up status should integrate with that existing infrastructure rather than introduce a parallel raw publisher.

This is also a worked instance of the workspace pattern documented in memory `feedback_wifi_disconnect_not_an_error` — link-conditions events belong in DiagnosticStatus, not WARN logs.

## Approach

1. **Demote per-event WARN to DEBUG** at `remote_node.cpp:329-334`. One-line change (`RCLCPP_WARN_STREAM` → `RCLCPP_DEBUG_STREAM`). Per-event detail stays available in bags for forensic analysis; live operator log panels stay clean. Independently testable — restores quiet logs even if step 2 spills.

2. **Add per-remote diagnostic task** that publishes give-up rate + cumulative count + threshold-based level. Hook into the existing `diagnostic_updater_` at the per-`RemoteNode` level (parallel to existing per-connection tasks in `udp_bridge.cpp:1495-1507`). New helper `UDPBridge::diagnoseRemoteGiveups(remote_name, stat)` mirrors `diagnoseConnection`'s shape. Diagnostic task name follows the existing convention: `"udp_bridge " + name_ + ": " + remote_name + ": resend give-ups"` (mirrors the per-connection format at `udp_bridge.cpp:1498` — this is a deliberate divergence from the owner's comment wording, which proposed `"udp_bridge: resend give-ups for '<remote>'"`; the convention-conforming form is preferred for consistency with the existing aggregator output).

   **State**: `last_giveup_count_` and `last_giveup_publish_time_` per-remote maps live on `UDPBridge` and are guarded by the **existing `remote_nodes_mutex_`** (extended scope — short reads inside the diagnostic callback, no new lock introduced). Reset-safe: if `current_count < last_count`, publish rate=0 (handles counter reset per [#21](https://github.com/rolker/udp_bridge/issues/21) observation).

   **Lifecycle**: cleared in `on_cleanup` alongside the existing `diagnostic_task_names_` clear at `udp_bridge.cpp:364`. `diagnostic_updater::Updater` has no per-task `remove()` API, so re-registration of the same task name after activate→deactivate→activate must be guarded the same way `diagnostic_task_names_` already gates re-adds (line 1499). The diagnostic callback's "remote not registered" branch mirrors `diagnoseConnection`'s `STALE` return (line 1520).

3. **Declare thresholds as ROS 2 parameters**, not `const`. Defaults: `resend_giveup_warn_rate_per_s=5.0`, `resend_giveup_error_rate_per_s=50.0` — confirmed with owner. Calibrated against the 2026-05-19 storm (~700/s peak / ~3.9/s average steady): the average correctly fires WARN, the burst correctly fires ERROR. Lower-WARN-threshold question (Open Question 2 below) deferred — start with 5/50 and revisit if operators report missing mild-loss signal. Parameters allow field tuning via YAML without rebuild.

4. **Tests** — extend `test/test_remote_node_resend.cpp` is *not* the right home for the publisher tests (RemoteNode doesn't know about the diagnostic infrastructure — only exposes `resendGiveupCount()`).

   **Test strategy**: extract the rate/threshold logic into a **static free function** so it can be tested without bringing up a `UDPBridge` instance. Proposed signature:

   ```cpp
   struct GiveupDiagnostic {
     uint8_t level;        // diagnostic_msgs::DiagnosticStatus OK/WARN/ERROR
     double rate_per_s;
     uint32_t total;
   };

   GiveupDiagnostic computeGiveupDiagnostic(
       uint32_t prev_count,
       uint32_t current_count,
       double elapsed_s,
       double warn_thresh,
       double error_thresh);
   ```

   The free function lives in a small new header (`udp_bridge/include/udp_bridge/giveup_diagnostic.h`) and is consumed by `UDPBridge::diagnoseRemoteGiveups()` as a thin wrapper. Test file `test/test_giveup_diagnostic.cpp` exercises:

   - Steady-state rate calculation
   - Counter reset (`current < prev` → rate=0, level=OK)
   - Threshold transitions OK↔WARN↔ERROR at the configured cutoffs
   - **First-call behavior** (no prior call → caller passes `prev_count=0` and the function must return rate=0 without dividing by `elapsed_s=0`)
   - **Zero-elapsed-time edge case** (`elapsed_s == 0` → must not divide by zero; return rate=0)
   - Multi-remote independence is covered by the wrapper-side state isolation (separate map entries), not by this helper — verified at integration level via a follow-up sanity-check rather than a dedicated unit test.

   Determinism: the free function takes `elapsed_s` as a parameter, so the test doesn't need a clock at all — the time-dependence is moved out of the test fixture and into the caller. The wrapper `diagnoseRemoteGiveups()` uses `this->now()` (controllable via `use_sim_time` if a future integration test wants it).

## Files to Change

| File | Change |
|------|--------|
| `udp_bridge/src/remote_node.cpp:329-334` | `RCLCPP_WARN_STREAM` → `RCLCPP_DEBUG_STREAM` (1-line severity change; message text unchanged) |
| `udp_bridge/src/udp_bridge.cpp` | Declare 2 new parameters (`resend_giveup_warn_rate_per_s`, `resend_giveup_error_rate_per_s`); register per-remote diagnostic task in the same loop as existing per-connection tasks (~1500); implement `diagnoseRemoteGiveups()` (~30 LOC — most logic moves to the free function); clear new maps in `on_cleanup` alongside existing `diagnostic_task_names_` reset (~364) |
| `udp_bridge/include/udp_bridge/udp_bridge.h` | Declare `diagnoseRemoteGiveups()`; add `last_giveup_count_` / `last_giveup_publish_time_` per-remote maps guarded by `remote_nodes_mutex_`; declare parameter members |
| `udp_bridge/include/udp_bridge/giveup_diagnostic.h` | **NEW** — header for `computeGiveupDiagnostic()` free function (~25 LOC including the `GiveupDiagnostic` struct) |
| `udp_bridge/test/test_giveup_diagnostic.cpp` | **NEW** — gtest covering steady-state rate, counter reset, threshold transitions, first-call (`prev_count=0`), zero-elapsed-time edge case |
| `udp_bridge/CMakeLists.txt` | Register the new test executable |
| `udp_bridge/README.md` | Add a "Diagnostic surface" section (or extend existing) documenting the new `resend give-ups for '<remote>'` diagnostic name + threshold parameters |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Human control and transparency | DiagnosticStatus is *more* informative than per-event WARN spam — a single aggregator indicator with rate metric beats 200/min of noise. Operators get a tunable surface (params), not a hard-coded behavior. |
| A change includes its consequences | Test coverage added in step 4; README updated; existing `test_remote_node_resend.cpp` continues to verify counter correctness unchanged. |
| Only what's needed | Reuses existing `diagnostic_updater_` infrastructure + existing `resendGiveupCount()` accessor + existing `Remote.msg.resend_giveup_count` field. No new accounting state introduced. ~50 LOC plus tests. |
| Test what breaks | Test scope matches the field-observed failure modes: counter reset across `udp_bridge` restart (per #21), threshold boundaries calibrated against the 2026-05-19 storm, multi-remote independence (storm hit both directions). |
| Improve incrementally | Two atomic commits: step 1 (one-line WARN→DEBUG) is independently mergeable; step 2 (diagnostic publisher + parameters + tests + README) is its own commit. |
| Enforcement over documentation | The "link-conditions events go through DiagnosticStatus, not WARN" rule that this plan applies is a workspace convention (memory `feedback_wifi_disconnect_not_an_error`), not enforcement. Applying the convention here is the right step; broader enforcement (a grep / lint that flags `RCLCPP_WARN` near `resend_giveup_count_` and similar patterns) is acknowledged as out of scope for this PR. |
| Workspace vs. project separation | Pure project change in `udp_bridge`. No workspace coupling. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| [0008 — Follow ROS 2 Official Conventions](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0008-follow-ros2-official-conventions.md) | Yes | Use `diagnostic_updater::Updater` (already present in this package), not a raw `DiagnosticStatus` publisher — the higher-level API is the standard ROS 2 convention and integrates cleanly with `diagnostic_aggregator`. New parameters declared via `declare_parameter()` per ROS 2 convention. |
| [0001 — Adopt ADRs](https://github.com/rolker/ros2_agent_workspace/blob/main/docs/decisions/0001-adopt-architecture-decision-records.md) | Watch | Single-package severity/diagnostic change — no ADR needed in this repo. The broader workspace pattern ("link-conditions events go through DiagnosticStatus") may deserve an ADR if it cascades to other packages; flag as a follow-up question rather than block. |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| Demote a public-facing WARN | Bag-replay workflows that grep for "Giving up on resend" in `/rosout` | Yes — README will note the demotion and the new diagnostic surface |
| Add new diagnostic task name | Operator-side annunciator (`unh_echoboats_project11`'s `bizzyboat_operator_annunciator`) — if it uses an allowlist, the new name has to be added | **Open question** — annunciator's filter behavior should be checked before merge |
| Add new ROS 2 parameters | Deployment YAMLs that override udp_bridge parameters (BizzyBoat / IzzyBoat launch configs) | No, defaults are sensible; per-deployment override is optional |
| Add new test file | `CMakeLists.txt` test registration | Yes — explicit in Files to Change |

## Open Questions

1. **Annunciator filter behavior**: does the operator-side annunciator allowlist diagnostic task names, or does it accept any `udp_bridge: *` pattern? If allowlisted, this PR needs a paired follow-up commit on `unh_echoboats_project11`. Owner deferred — spot-check during implementation by reading the annunciator's diagnostic-subscription config; if allowlisted, file a paired follow-up issue rather than block this PR.

2. **Threshold lower-WARN question** (deferred): owner accepted 5/50 starting defaults. The deferred question is whether the WARN threshold should be lowered (e.g., to 1/s) in a future tuning pass to flag mild loss earlier. Not blocking this PR — surface as a follow-up if operators report missing-signal in the field.

## Decided (during planning, after owner input 2026-05-20)

- **Thresholds**: 5/s WARN, 50/s ERROR (starting defaults; parameter-tunable per Approach step 3).
- **Diagnostic task naming**: use the existing convention from `udp_bridge.cpp:1498` — `"udp_bridge " + name_ + ": " + remote_name + ": resend give-ups"`.
- **Mutex strategy**: extend `remote_nodes_mutex_` scope to cover the new per-remote diag maps (no new mutex introduced).
- **Test fixture approach**: extract rate calc into a `computeGiveupDiagnostic()` static free function in `udp_bridge/include/udp_bridge/giveup_diagnostic.h`; test the helper directly (no `UDPBridge` instance, no clock fixture needed).

## Estimated Scope

Single PR, two atomic commits. Estimated diff: ~80 LOC implementation (split: ~30 LOC `UDPBridge::diagnoseRemoteGiveups()` wrapper + ~25 LOC `giveup_diagnostic.h` free function + ~25 LOC parameter / map / cleanup wiring) + ~150 LOC tests + ~20 LOC README. No cross-repo coordination required other than the annunciator allowlist check (Open Question 1).


---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
