### PR TITLE
[PLAN] Restrict resend response to the connection the request arrived on (add connection_id to ResendRequest)

### DIFF
--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -247,6 +247,55 @@ PR #13.
   reworded the surrounding comments — the invariant under test is
   "no broadcast fallback," not "no log output."
 
+- **Self-review must-fix (round-8 fix).** A local `/review-code` pass
+  (Claude + Copilot adversarial specialists, post-jazzy-merge) caught
+  two real issues that the prior six rounds of Copilot review had
+  missed:
+  1. **`DispatchHonorsTruncatedConnectionId` asserted a false
+     wire-contract invariant.** The test called
+     `dispatchResendRequest` directly with `"starlink"` (8 chars) and
+     claimed that a counter bump there would mean "any id longer
+     than 7 chars silently loses resends in the field." That claim
+     became false in round-3 once the receive-side clamp landed in
+     `UDPBridge::decodeResendRequest`: in production, an unclamped
+     8-char id from a buggy sender now clamps to 7 chars before
+     reaching dispatch, so the resend would route correctly. The
+     test only proves "dispatch doesn't fuzzy-match" — a real
+     invariant but a narrower one. Renamed to
+     `DispatchDoesNotFuzzyMatchConnectionId` and rewrote the comment
+     block to be honest about the integration-test gap (sender-side
+     truncation and receive-side clamp are both inside the private
+     wire-decode plumbing of `UDPBridge`; verifying their full
+     integration would require either friend-declaring a test entry
+     to `decodeResendRequest` or a wire-format integration test that
+     constructs a real packet — both out of scope for this unit
+     suite).
+  2. **WARN log overstated the rate-limit promise.** The WARN at
+     `remote_node.cpp:222` said "Further misses for this id will log
+     at DEBUG." — but with FIFO eviction (cap 256, added round-4),
+     an evicted id re-WARNs the next time it's seen. The field
+     comment explicitly documents this as the desired
+     "WARN-eligible again next time" behavior; the user-facing
+     string contradicted it. Updated to "Further misses for this id
+     will log at DEBUG (until the rate-limit table evicts this id
+     under pressure, at which point the WARN re-fires on next
+     sighting)." Same comment-vs-code drift pattern Copilot had been
+     flagging — this one slipped through the externally-driven
+     rounds because no external review reached this specific string.
+  3. **`DispatchMissWarnedIdsAreBounded` ceiling too loose.** The
+     test asserted `count <= 512u` when the cap is 256, so a
+     "doubled cap" regression would have slipped past. Tightened to
+     `EXPECT_EQ(count, kDispatchMissWarnedCap)` via a new
+     `dispatchMissWarnedCapForTest()` static accessor (the constant
+     is private; the accessor keeps it that way for production code).
+     Also added a FIFO-order assertion via a new
+     `isDispatchMissWarnedForTest(const std::string&)` accessor:
+     after pushing more ids than the cap, the most-recently-pushed
+     id MUST still be in the table and the earliest-pushed id MUST
+     have been evicted. A regression that evicted from the tail
+     (LIFO) or evicted arbitrarily would now fail this — the
+     previous test only checked the bound, not the order.
+
 - **try/catch comment correction (round-7 fix).** Copilot's fifth
   review caught that round-3's try/catch rationale in
   `decodeResendRequest` (and the matching wording in

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -70,16 +70,19 @@ design forks:
      call `dispatchResendRequest`; assert
      `wifi.resend_call_count_for_test() == 1` and
      `vpn.resend_call_count_for_test() == 0`.
-   - **Stamped id no longer present.** Set up both connections, then tear
-     down `"wifi"` (drop it from `connections_` — exercise the production
-     path via whatever method already removes connections, or via a
-     `UDP_BRIDGE_BUILD_TESTING`-gated helper if none is reachable); send a
-     `ResendRequest` stamped for `"wifi"`; assert both counters stay at 0
-     (this is the legitimate sender/receiver race during a CONNECT cycle).
-   - **Unknown id (config mismatch).** Smaller third test: stamp for a
-     never-registered id; assert both counters stay at 0. Same code path
-     as the stale-id case but distinct framing for the operator-facing
-     diagnostic.
+   - **Stamped id absent (transient state).** Register only `"vpn"`;
+     stamp `ResendRequest` for `"wifi"`. Models the post-restart /
+     pre-BridgeInfo-reconciliation window where the receiver hasn't
+     re-registered the connection yet. Assert vpn's counter stays at 0
+     (must not fall back to broadcast). No new helper needed — the test
+     achieves the absent-id state by initial population alone; a
+     removal helper would only add production-adjacent API for no extra
+     coverage.
+   - **Unknown id (config mismatch).** Register both `"wifi"` and
+     `"vpn"`; stamp for `"starlink"` (an id this RemoteNode has never
+     seen). Same lookup-miss code path as the absent-id case; differs
+     in the `known_ids` payload of the DEBUG log, which documents the
+     two operator scenarios. Assert both counters stay at 0.
 7. **Follow-up comment on #18.** After PR opens, post a short note listing
    suggested bench scenarios: (a) verify per-connection routing under
    normal traffic, (b) verify no resends fan out to a path with rx loss,
@@ -95,7 +98,8 @@ design forks:
 | `udp_bridge/src/remote_node.cpp` | Implement `dispatchResendRequest` |
 | `udp_bridge/include/udp_bridge/connection.h` | Add `resend_call_count_for_test()` under `UDP_BRIDGE_BUILD_TESTING`; counter member under same gate |
 | `udp_bridge/src/connection.cpp` | Increment counter at entry of `resend_packets` (gated) |
-| `udp_bridge/test/test_remote_node_resend.cpp` | Two new `TEST_F`s: matched-id routing; unknown-id no-op |
+| `udp_bridge/test/test_remote_node_resend.cpp` | Three new `TEST_F`s (matched-id routing; stamped-id-absent; unknown-id) + a `ScopedFd` RAII helper for unbound UDP socket |
+| `udp_bridge/CMakeLists.txt` | Add `add_udp_bridge_gtest()` helper that wraps `ament_add_gtest` + `target_compile_definitions(UDP_BRIDGE_BUILD_TESTING)` + `target_link_libraries`. Extend the macro to every test target (previously only on two) — see Implementation Notes for the ODR rationale |
 
 ## Principles Self-Check
 
@@ -132,3 +136,23 @@ in the PR body so it's visible to whoever cuts the deployment.
 
 Single PR. ~80 LOC code + ~50 LOC test. Comparable to the resend-loop work in
 PR #13.
+
+## Implementation Notes
+
+- **ODR pitfall surfaced in CMakeLists.** The plan called for a
+  `UDP_BRIDGE_BUILD_TESTING`-gated counter on `Connection`. The existing
+  test-only helpers (`record_sent_packet_for_test`,
+  `sent_packet_count_for_test`) are method-only and don't change class
+  layout; my counter, however, is a real data member (`std::size_t
+  resend_call_count_for_test_`) and therefore changes `sizeof(Connection)`
+  when the macro is defined. Before the CMakeLists change, only two test
+  targets defined the macro — the rest (notably
+  `test_connection_rate_limit`, which constructs `Connection` directly)
+  compiled against a smaller layout while linking to a library compiled
+  with the larger layout. That ODR mismatch reproduced as a clean
+  segfault in `ConcurrentSendsStayUnderLimit`. The fix wraps every test
+  target in `add_udp_bridge_gtest()` so they all carry the macro; the
+  existing namespaced-macro comment already anticipated the downstream-
+  consumer hazard but didn't extend the discipline to in-package tests.
+  Documented in CMakeLists so a future agent adding another counter
+  doesn't have to re-discover this.

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -247,6 +247,31 @@ PR #13.
   reworded the surrounding comments — the invariant under test is
   "no broadcast fallback," not "no log output."
 
+- **try/catch comment correction (round-7 fix).** Copilot's fifth
+  review caught that round-3's try/catch rationale in
+  `decodeResendRequest` (and the matching wording in
+  `ResendRequest.msg`) overstated the benefit. Both comments
+  claimed the site-specific catch was load-bearing for executor
+  survival ("logs+drops … rather than letting the exception
+  propagate to the executor and kill the bridge"). Verified false:
+  `UDPBridge::decode()` at `udp_bridge.cpp:568-614` already wraps
+  every `decode*` dispatch (including `decodeResendRequest` at line
+  596-598) in a catch-all that logs an ERROR and continues. The
+  inner catch's real benefit is **diagnostic clarity** — it emits
+  a site-specific WARN naming the source bridge and the failure
+  kind ("Failed to deserialize ResendRequest from <node> (<host>:
+  <port>)") so an operator chasing a known coordinated-redeploy
+  mismatch can confirm it's the ResendRequest schema that's out of
+  sync, instead of having to interpret the outer's generic
+  "decoding error on packet of type N" ERROR. Both comments
+  rewritten to describe the actual contract and explicitly call
+  out that executor survival comes from the outer catch, not this
+  one. The follow-up note about other `decode*` sites (notably
+  `decodeMessageInternal`) was also updated to reflect that the
+  outer catch is enough for survival there too — mirroring the
+  site-specific pattern is now framed as a diagnostic-payoff
+  judgment call, not a survival requirement.
+
 - **Comment + DEBUG-path + test-log polish (round-6 fix).** Three
   small follow-ups from Copilot's fourth review (against the round-5
   push at `3f40162`):

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -247,6 +247,47 @@ PR #13.
   reworded the surrounding comments — the invariant under test is
   "no broadcast fallback," not "no log output."
 
+- **Header hygiene + in-package ABI alignment (round-5 fix).** Two
+  precise findings from Copilot's third review (against the round-4
+  push at `5225c2e`):
+  1. **Missing `<set>` include.** Round-4 dropped `#include <set>`
+     from `remote_node.h` when replacing the WARN-bookkeeping set,
+     but `given_up_packet_numbers_` at line 260 still uses
+     `std::set<uint64_t>`. The build was passing only because
+     `udp_bridge.h:10` transitively pulled in `<set>`. Re-added the
+     direct include alongside the new `<deque>` / `<unordered_set>`.
+  2. **In-package ABI mismatch on `udp_bridge_node`.** The library
+     target was being compiled with `UDP_BRIDGE_BUILD_TESTING`
+     defined under `BUILD_TESTING=ON` (larger `Connection` /
+     `RemoteNode` layouts), but the `udp_bridge_node` executable
+     target was not — and its translation unit includes `udp_bridge.h`
+     which directly includes `connection.h`, so the executable
+     compiled against the production layout while linking a
+     test-augmented library. The original CMake comment block called
+     out the same hazard for **downstream-package** consumers but
+     didn't extend the discipline to **in-package** consumers
+     (executable + tests). Test targets were already covered by the
+     `add_udp_bridge_gtest()` helper added in round-2; the executable
+     was the remaining gap. Fix: add
+     `target_compile_definitions(udp_bridge_node PRIVATE UDP_BRIDGE_BUILD_TESTING)`
+     inside the existing `if(BUILD_TESTING)` block, with a new
+     comment paragraph documenting why the executable needs the same
+     discipline as the test targets. The mismatch hadn't bitten us
+     in practice because the executable never allocates `Connection`
+     by value and no inline methods on Connection touch conditional
+     members, but it's UB per the standard and is exactly the kind
+     of latent ABI hazard the existing CMake comment was already
+     designed to prevent.
+
+  This also walks back the "false positive" classification I'd
+  attached to Copilot's original CMake/ODR finding in the round-1
+  triage. The finding's framing — "downstream targets that link
+  against this library" — was technically correct only for the
+  downstream-package case I covered (where no consumers exist
+  outside udp_bridge), but the underlying principle (layout-changing
+  macros in installed headers are an ODR hazard for any consumer)
+  applied to the in-package executable I had failed to audit.
+
 - **Bounded FIFO for dispatch-miss WARN bookkeeping (round-4 fix).**
   Copilot's second review on PR #25 (against the round-3 push) flagged
   that the round-3 receive-side clamp only bounded each entry's *size*

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -246,3 +246,26 @@ PR #13.
   diagnostic output. Renamed to `DispatchDropsWithoutBroadcast*` and
   reworded the surrounding comments — the invariant under test is
   "no broadcast fallback," not "no log output."
+
+- **Bounded FIFO for dispatch-miss WARN bookkeeping (round-4 fix).**
+  Copilot's second review on PR #25 (against the round-3 push) flagged
+  that the round-3 receive-side clamp only bounded each entry's *size*
+  (7 bytes), not the *count* of distinct ids. A peer could still
+  drive `dispatch_miss_warned_ids_` count upward without bound, and the
+  field comment still claimed boundedness it didn't enforce. Round-4
+  replaces the `std::set<std::string>` with a bounded FIFO: a
+  `std::deque<std::string>` for insertion order plus an
+  `std::unordered_set<std::string>` for O(1) presence checks, capped at
+  `kDispatchMissWarnedCap = 256` entries. On insertion past the cap,
+  the oldest entry is evicted from both containers — that id becomes
+  WARN-eligible again the next time it's seen, which is the right
+  behavior for a rate-limit-the-WARN table (versus permanently
+  silencing a stale id). Cap value is chosen to be comfortably above
+  any plausible configured id space (typical deployments have 2–4
+  connections). A `UDP_BRIDGE_BUILD_TESTING`-gated
+  `dispatchMissWarnedIdCountForTest()` accessor mirrors the existing
+  test-only-accessor pattern and is used by a new
+  `DispatchMissWarnedIdsAreBounded` test that pushes 1024 distinct ids
+  and asserts the bookkeeping size converges well below the push count.
+  Field comment on `dispatch_miss_warned_ids_` rewritten to describe
+  what's actually enforced and why.

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -33,56 +33,76 @@ design forks:
 
 1. **`ResendRequest.msg` — add `string connection_id`** with a comment matching
    the tone of `MessageInternal.msg`'s coordinated-redeploy caveat.
-2. **`UDPBridge::resendMissingPackets` — stamp per connection.** Replace the
-   single `send(rr, remote.first, true)` broadcast with a per-connection loop:
-   build a fresh `ResendRequest` for each live connection, stamp `connection_id`,
-   send through that connection only via a `RemoteConnectionsList` carrying just
-   that one id. Hold the existing snapshot-then-iterate pattern (the locking
-   shape is unchanged).
+2. **`UDPBridge::resendMissingPackets` — stamp per connection (truncated).**
+   Replace the single `send(rr, remote.first, true)` broadcast with a
+   per-connection loop: build a fresh `ResendRequest` for each live connection,
+   stamp `connection_id` **truncated to `maximum_connection_id_size - 1`**
+   (the same limit `WrappedPacket` enforces on the on-wire char array at
+   `wrapped_packet.cpp:31-32`), send through that connection only via a
+   `RemoteConnectionsList` carrying that one id. The truncation is the
+   load-bearing detail: the receiver's `connections_` map is keyed on the
+   already-truncated id (populated from packet headers in
+   `RemoteNode::unwrap`), so stamping the full string would cause silent
+   resend-routing loss for any configured id ≥ 8 chars (`starlink`,
+   `cellular`, …). Hold the existing snapshot-then-iterate pattern (the
+   locking shape is unchanged).
 3. **Move routing into `RemoteNode`.** Add
    `RemoteNode::dispatchResendRequest(const ResendRequest&, int socket, rclcpp::Time now)`
    that looks up `connection(rr.connection_id)` and calls `resend_packets` on
    exactly that connection. If the id is not in `connections_`, no-op and
-   emit a DEBUG log that names both the stamped id and the set of currently
-   known connection ids — this branch fires both on legitimate races (sender
-   stamped while the receiver was tearing the connection down for a CONNECT
-   cycle or config reload) and on bona-fide coordinated-redeploy mismatches,
-   so the log line needs to give an operator chasing either case enough to
-   diagnose. Keeps the routing logic on the class that owns the connection
-   map and is already directly constructed in `test_remote_node_resend.cpp`'s
-   fixture.
-4. **`UDPBridge::decodeResendRequest` becomes a thin shim.** Snapshot the
-   matching `RemoteNode` under `remote_nodes_mutex_`, then call
-   `dispatchResendRequest` outside the lock (same pattern as today —
-   network I/O outside `remote_nodes_mutex_`).
+   emit a log that names both the stamped id and the set of currently
+   known connection ids. Use **WARN the first time** we see an unrecognized id
+   on this RemoteNode (so a real config mismatch is diagnosable at default log
+   levels) and **DEBUG on subsequent misses for the same id** (so legitimate
+   CONNECT-cycle races don't spam). Bookkeeping is a `std::set<std::string>`
+   on RemoteNode guarded by `state_mutex_` — never pruned, bounded by the
+   configuration space of legitimate-then-removed ids. Keeps the routing
+   logic on the class that owns the connection map and is already directly
+   constructed in `test_remote_node_resend.cpp`'s fixture.
+4. **`UDPBridge::decodeResendRequest` becomes a thin shim with try/catch.**
+   Wrap `deserialize<ResendRequest>(message)` in a `try { … } catch(const
+   std::exception&)` block that logs+drops on failure — makes good on the
+   "logs+drops on deserialization failure" promise the new `ResendRequest.msg`
+   comment makes. Then snapshot the matching `RemoteNode` under
+   `remote_nodes_mutex_` and call `dispatchResendRequest` outside the lock
+   (same pattern as today — network I/O outside `remote_nodes_mutex_`). The
+   parallel gap in `decodeMessageInternal` (which `MessageInternal.msg` also
+   wrongly promises is guarded) is pre-existing and gets its own follow-up
+   issue rather than expanding scope here.
 5. **Test seam: per-connection resend-call counter.** Add a
    `UDP_BRIDGE_BUILD_TESTING`-gated `resend_call_count_for_test()` accessor on
    `Connection`. `resend_packets` increments the counter at entry (before the
    network I/O). Mirrors the existing `record_sent_packet_for_test` /
    `sent_packet_count_for_test` pattern at `connection.h:102-127`.
-6. **Unit tests.** New `TEST_F`s in `test_remote_node_resend.cpp`. Common
-   setup: `RemoteNode` with two `Connection`s (`"wifi"`, `"vpn"`); seed a
-   sent packet on each via `record_sent_packet_for_test`; dummy socket
-   obtained via `socket(AF_INET, SOCK_DGRAM, 0)` left unbound and `close()`d
-   on teardown — `sendto` will fail benignly but the counter is what we
-   assert on, not the I/O.
-   - **Matched-id routing.** Build a `ResendRequest` stamped for `"wifi"`;
-     call `dispatchResendRequest`; assert
-     `wifi.resend_call_count_for_test() == 1` and
-     `vpn.resend_call_count_for_test() == 0`.
+6. **Unit tests.** Four new `TEST_F`s in `test_remote_node_resend.cpp`.
+   Common setup: `RemoteNode` with `Connection`s constructed via
+   `newConnection`; `ScopedFd` RAII helper opens a real UDP socket via
+   `socket(AF_INET, SOCK_DGRAM, 0)` (kernel accepts the loopback datagram
+   even with no listener — `Connection::resend_packets` increments the
+   counter at function entry before any sendto, so I/O outcome doesn't
+   affect the assertion). No `record_sent_packet_for_test` seeding —
+   the test counter is bumped pre-lookup, so seeding wouldn't change
+   anything and would be misleading scaffolding.
+   - **Matched-id routing.** Two connections (`"wifi"`, `"vpn"`); stamp
+     for `"wifi"`; assert wifi's counter is 1 and vpn's is 0.
    - **Stamped id absent (transient state).** Register only `"vpn"`;
-     stamp `ResendRequest` for `"wifi"`. Models the post-restart /
-     pre-BridgeInfo-reconciliation window where the receiver hasn't
-     re-registered the connection yet. Assert vpn's counter stays at 0
-     (must not fall back to broadcast). No new helper needed — the test
-     achieves the absent-id state by initial population alone; a
-     removal helper would only add production-adjacent API for no extra
-     coverage.
+     stamp for `"wifi"`. Models the post-restart / pre-BridgeInfo-
+     reconciliation window where the receiver hasn't re-registered the
+     connection yet. Assert vpn's counter stays at 0 (must not fall
+     back to broadcast).
    - **Unknown id (config mismatch).** Register both `"wifi"` and
-     `"vpn"`; stamp for `"starlink"` (an id this RemoteNode has never
+     `"vpn"`; stamp for `"iridium"` (an id this RemoteNode has never
      seen). Same lookup-miss code path as the absent-id case; differs
-     in the `known_ids` payload of the DEBUG log, which documents the
+     in the `known_ids` payload of the WARN log, which documents the
      two operator scenarios. Assert both counters stay at 0.
+   - **Truncated-id contract.** Register a connection keyed on the
+     truncated form (`"starlin"`, what the receiver would have after
+     packets from a configured-as-`"starlink"` connection arrive).
+     Two-part assertion: stamp with `"starlin"` (the post-fix sender
+     behavior) — counter goes to 1; stamp with `"starlink"` (the
+     pre-fix bug) — counter stays at 1 (lookup misses). Documents the
+     wire contract and catches any regression that reintroduces the
+     full-id stamp.
 7. **Follow-up comment on #18.** After PR opens, post a short note listing
    suggested bench scenarios: (a) verify per-connection routing under
    normal traffic, (b) verify no resends fan out to a path with rx loss,
@@ -98,7 +118,7 @@ design forks:
 | `udp_bridge/src/remote_node.cpp` | Implement `dispatchResendRequest` |
 | `udp_bridge/include/udp_bridge/connection.h` | Add `resend_call_count_for_test()` under `UDP_BRIDGE_BUILD_TESTING`; counter member under same gate |
 | `udp_bridge/src/connection.cpp` | Increment counter at entry of `resend_packets` (gated) |
-| `udp_bridge/test/test_remote_node_resend.cpp` | Three new `TEST_F`s (matched-id routing; stamped-id-absent; unknown-id) + a `ScopedFd` RAII helper for unbound UDP socket |
+| `udp_bridge/test/test_remote_node_resend.cpp` | Four new `TEST_F`s (matched-id routing; stamped-id-absent; unknown-id; truncated-id contract) + a `ScopedFd` RAII helper for the dispatch dummy socket |
 | `udp_bridge/CMakeLists.txt` | Add `add_udp_bridge_gtest()` helper that wraps `ament_add_gtest` + `target_compile_definitions(UDP_BRIDGE_BUILD_TESTING)` + `target_link_libraries`. Extend the macro to every test target (previously only on two) — see Implementation Notes for the ODR rationale |
 
 ## Principles Self-Check
@@ -156,3 +176,38 @@ PR #13.
   consumer hazard but didn't extend the discipline to in-package tests.
   Documented in CMakeLists so a future agent adding another counter
   doesn't have to re-discover this.
+
+- **Connection-id 8-char wire limit (round-2 fix).** The first
+  implementation pass stamped `connection->id()` (the full configured
+  string) into `ResendRequest.connection_id`. Review caught that the
+  on-wire `SequencedPacketHeader` carries a fixed `char[8]` connection
+  id (per `maximum_connection_id_size = 8`, originally added 2023-06-20
+  when the bridge moved off UDP-return-address routing). The receiver's
+  `connections_` map is keyed on the truncated id (populated from
+  packet headers in `RemoteNode::unwrap`), so the full-string stamp
+  would have caused silent resend-routing loss for any configured id
+  ≥ 8 chars — and `"starlink"` is exactly 8. Fix: truncate the stamp
+  to `maximum_connection_id_size - 1` in `resendMissingPackets`,
+  mirroring what `WrappedPacket` already does at
+  `wrapped_packet.cpp:31-32`. Round-2 also added the
+  `DispatchHonorsTruncatedConnectionId` test as a regression guard.
+  Not addressed here: raising the 8-byte limit (would require a
+  wire-format change to every data packet header — separate issue).
+
+- **try/catch on `decodeResendRequest` (round-2 fix).** The new
+  `ResendRequest.msg` comment originally claimed the receiver wrapped
+  decode in try/catch (mirroring `MessageInternal.msg`'s comment) —
+  review caught that no such wrap actually existed at
+  `decodeResendRequest`, *or* at `decodeMessageInternal`. Round-2 added
+  the wrap at the `decodeResendRequest` site this PR introduces and
+  tightened the message comment to be specific (not a systemic claim).
+  The pre-existing `decodeMessageInternal` gap is left for a follow-up
+  issue rather than expanding scope.
+
+- **Dispatch-miss WARN once-per-id (round-2 fix).** Review surfaced
+  that the original DEBUG-only log on dispatch lookup miss was too
+  quiet for genuine coordinated-redeploy mismatches (operator chasing
+  "resends stopped working" wouldn't see it at default log levels).
+  Promoted to WARN on first miss per id (state bookkeeping in a small
+  set on RemoteNode), DEBUG on subsequent — surfaces real config
+  errors without spamming during legitimate CONNECT-cycle races.

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -42,10 +42,15 @@ design forks:
 3. **Move routing into `RemoteNode`.** Add
    `RemoteNode::dispatchResendRequest(const ResendRequest&, int socket, rclcpp::Time now)`
    that looks up `connection(rr.connection_id)` and calls `resend_packets` on
-   exactly that connection (no-op + DEBUG log if not found — only happens on
-   bona-fide config mismatch under coordinated-redeploy). Keeps the routing
-   logic on the class that owns the connection map and is already directly
-   constructed in `test_remote_node_resend.cpp`'s fixture.
+   exactly that connection. If the id is not in `connections_`, no-op and
+   emit a DEBUG log that names both the stamped id and the set of currently
+   known connection ids — this branch fires both on legitimate races (sender
+   stamped while the receiver was tearing the connection down for a CONNECT
+   cycle or config reload) and on bona-fide coordinated-redeploy mismatches,
+   so the log line needs to give an operator chasing either case enough to
+   diagnose. Keeps the routing logic on the class that owns the connection
+   map and is already directly constructed in `test_remote_node_resend.cpp`'s
+   fixture.
 4. **`UDPBridge::decodeResendRequest` becomes a thin shim.** Snapshot the
    matching `RemoteNode` under `remote_nodes_mutex_`, then call
    `dispatchResendRequest` outside the lock (same pattern as today —
@@ -55,14 +60,26 @@ design forks:
    `Connection`. `resend_packets` increments the counter at entry (before the
    network I/O). Mirrors the existing `record_sent_packet_for_test` /
    `sent_packet_count_for_test` pattern at `connection.h:102-127`.
-6. **Unit test.** New `TEST_F` in `test_remote_node_resend.cpp`: set up a
-   `RemoteNode` with two `Connection`s (`"wifi"`, `"vpn"`); seed a sent packet
-   on each via `record_sent_packet_for_test`; build a `ResendRequest` stamped
-   for `"wifi"`; call `dispatchResendRequest` with a dummy `socket` (use a
-   throwaway UDP socket on loopback so `sendto` doesn't fail in a confusing
-   way); assert `wifi.resend_call_count_for_test() == 1` and
-   `vpn.resend_call_count_for_test() == 0`. Second test: stamp for an
-   unknown id; assert both counters stay at 0 (no-op path).
+6. **Unit tests.** New `TEST_F`s in `test_remote_node_resend.cpp`. Common
+   setup: `RemoteNode` with two `Connection`s (`"wifi"`, `"vpn"`); seed a
+   sent packet on each via `record_sent_packet_for_test`; dummy socket
+   obtained via `socket(AF_INET, SOCK_DGRAM, 0)` left unbound and `close()`d
+   on teardown — `sendto` will fail benignly but the counter is what we
+   assert on, not the I/O.
+   - **Matched-id routing.** Build a `ResendRequest` stamped for `"wifi"`;
+     call `dispatchResendRequest`; assert
+     `wifi.resend_call_count_for_test() == 1` and
+     `vpn.resend_call_count_for_test() == 0`.
+   - **Stamped id no longer present.** Set up both connections, then tear
+     down `"wifi"` (drop it from `connections_` — exercise the production
+     path via whatever method already removes connections, or via a
+     `UDP_BRIDGE_BUILD_TESTING`-gated helper if none is reachable); send a
+     `ResendRequest` stamped for `"wifi"`; assert both counters stay at 0
+     (this is the legitimate sender/receiver race during a CONNECT cycle).
+   - **Unknown id (config mismatch).** Smaller third test: stamp for a
+     never-registered id; assert both counters stay at 0. Same code path
+     as the stale-id case but distinct framing for the operator-facing
+     diagnostic.
 7. **Follow-up comment on #18.** After PR opens, post a short note listing
    suggested bench scenarios: (a) verify per-connection routing under
    normal traffic, (b) verify no resends fan out to a path with rx loss,

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -247,6 +247,47 @@ PR #13.
   reworded the surrounding comments — the invariant under test is
   "no broadcast fallback," not "no log output."
 
+- **Comment + DEBUG-path + test-log polish (round-6 fix).** Three
+  small follow-ups from Copilot's fourth review (against the round-5
+  push at `3f40162`):
+  1. **Stale clamp-rationale comment.** Round-3 added the
+     receive-side clamp in `udp_bridge.cpp:decodeResendRequest` with
+     a rationale block that said `dispatch_miss_warned_ids_` "is
+     never pruned." Round-4 added FIFO eviction with cap
+     `kDispatchMissWarnedCap`, so the table IS pruned now. Updated
+     the comment to acknowledge the cap and reframe the clamp's
+     ongoing value (bounds per-entry size to 7 bytes; normalizes
+     incoming ids so the bookkeeping doesn't double-track truncated
+     and untruncated forms).
+  2. **Avoid wasted work on the DEBUG path in
+     `dispatchResendRequest`.** The `known_ids` snapshot (copy of all
+     keys in `connections_`) and the subsequent join into a comma-
+     separated string were built unconditionally on every lookup
+     miss, even though the DEBUG branch's message was the only
+     consumer of the join and DEBUG is typically off in production.
+     Restructured so both the `known_ids` snapshot (inside the lock)
+     and the join (after the lock) only happen when
+     `first_miss_for_id` is true; the DEBUG branch now emits a
+     compact message that references the prior WARN for this id
+     (cap-eviction-induced re-WARNs always carry the current
+     known-ids list, so an operator chasing a repeating issue
+     always has the snapshot on the most recent WARN line). Net
+     effect: repeated dispatch misses for a known-warned id pay no
+     join cost.
+  3. **Silence WARN spam in `DispatchMissWarnedIdsAreBounded`.** The
+     test pushed 1024 distinct ids to exercise the cap, emitting
+     ~1024 WARN log lines into the captured test output per run.
+     Reduced the push count to 288 (32 above the current 256 cap —
+     still proves 32 distinct evictions), and silenced the node's
+     logger for the duration of the loop via
+     `rclcpp::Logger::set_level(Error)` with a restore to the prior
+     level on exit. The cap-enforcement assertion uses
+     `dispatchMissWarnedIdCountForTest`, not log inspection, so the
+     silencing has no effect on what the test proves. Captured test
+     log dropped from ~1024 to 0 "Dropping ResendRequest" lines from
+     this test (the remaining 3 lines in the test log come from the
+     other dispatch-miss tests).
+
 - **Header hygiene + in-package ABI alignment (round-5 fix).** Two
   precise findings from Copilot's third review (against the round-4
   push at `5225c2e`):

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -1,0 +1,117 @@
+# Plan: Restrict resend response to the connection the request arrived on
+
+## Issue
+
+https://github.com/rolker/udp_bridge/issues/23
+
+## Context
+
+`UDPBridge::decodeResendRequest` (`udp_bridge.cpp:695-711`) currently iterates
+all connections to the source remote and calls `resend_packets` on each. A single
+`ResendRequest` therefore fans out to every active path. Combined with
+`resendMissingPackets` (`udp_bridge.cpp:965-983`) broadcasting the *request* to all
+paths, the cost under both-paths-alive is 4× resends per missing packet. The
+2026-05-19 bizzy field deployment exposed this: ~65 % of wifi outbound was
+resends (~950 KB/s), much of it sent into a wifi link that was rx-dead at the
+time.
+
+Per-issue review (`#23` comment) and user decision (2026-05-20) settle three
+design forks:
+
+1. **Coordinated-redeploy backward-compat**, not graceful field-add. The
+   `MessageInternal.msg` precedent in this same package explicitly states CDR
+   mixed-version interop is not guaranteed; we mirror that caveat on
+   `ResendRequest.msg` and drop the "broadcast fallback for empty
+   `connection_id`" branch entirely (it would never trigger cleanly anyway).
+2. **Bench harness (#18) is out of scope for this PR.** Unit test only; a
+   follow-up comment on #18 captures suggested scenarios.
+3. **Default-on, no config knob.** New behavior is a strict subset of old
+   coverage, but the only observed edge case (rx-only on one path) is rare and
+   recovered by give-up + the next regular send.
+
+## Approach
+
+1. **`ResendRequest.msg` — add `string connection_id`** with a comment matching
+   the tone of `MessageInternal.msg`'s coordinated-redeploy caveat.
+2. **`UDPBridge::resendMissingPackets` — stamp per connection.** Replace the
+   single `send(rr, remote.first, true)` broadcast with a per-connection loop:
+   build a fresh `ResendRequest` for each live connection, stamp `connection_id`,
+   send through that connection only via a `RemoteConnectionsList` carrying just
+   that one id. Hold the existing snapshot-then-iterate pattern (the locking
+   shape is unchanged).
+3. **Move routing into `RemoteNode`.** Add
+   `RemoteNode::dispatchResendRequest(const ResendRequest&, int socket, rclcpp::Time now)`
+   that looks up `connection(rr.connection_id)` and calls `resend_packets` on
+   exactly that connection (no-op + DEBUG log if not found — only happens on
+   bona-fide config mismatch under coordinated-redeploy). Keeps the routing
+   logic on the class that owns the connection map and is already directly
+   constructed in `test_remote_node_resend.cpp`'s fixture.
+4. **`UDPBridge::decodeResendRequest` becomes a thin shim.** Snapshot the
+   matching `RemoteNode` under `remote_nodes_mutex_`, then call
+   `dispatchResendRequest` outside the lock (same pattern as today —
+   network I/O outside `remote_nodes_mutex_`).
+5. **Test seam: per-connection resend-call counter.** Add a
+   `UDP_BRIDGE_BUILD_TESTING`-gated `resend_call_count_for_test()` accessor on
+   `Connection`. `resend_packets` increments the counter at entry (before the
+   network I/O). Mirrors the existing `record_sent_packet_for_test` /
+   `sent_packet_count_for_test` pattern at `connection.h:102-127`.
+6. **Unit test.** New `TEST_F` in `test_remote_node_resend.cpp`: set up a
+   `RemoteNode` with two `Connection`s (`"wifi"`, `"vpn"`); seed a sent packet
+   on each via `record_sent_packet_for_test`; build a `ResendRequest` stamped
+   for `"wifi"`; call `dispatchResendRequest` with a dummy `socket` (use a
+   throwaway UDP socket on loopback so `sendto` doesn't fail in a confusing
+   way); assert `wifi.resend_call_count_for_test() == 1` and
+   `vpn.resend_call_count_for_test() == 0`. Second test: stamp for an
+   unknown id; assert both counters stay at 0 (no-op path).
+7. **Follow-up comment on #18.** After PR opens, post a short note listing
+   suggested bench scenarios: (a) verify per-connection routing under
+   normal traffic, (b) verify no resends fan out to a path with rx loss,
+   (c) measure outbound bytes/sec reduction vs the broadcast baseline.
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `udp_bridge_interfaces/msg/ResendRequest.msg` | Add `string connection_id` field + coordinated-redeploy comment block |
+| `udp_bridge/src/udp_bridge.cpp` | Rewrite `resendMissingPackets` (per-connection stamp+send); rewrite `decodeResendRequest` as RemoteNode dispatch shim |
+| `udp_bridge/include/udp_bridge/remote_node.h` | Declare `dispatchResendRequest(const ResendRequest&, int, rclcpp::Time)` |
+| `udp_bridge/src/remote_node.cpp` | Implement `dispatchResendRequest` |
+| `udp_bridge/include/udp_bridge/connection.h` | Add `resend_call_count_for_test()` under `UDP_BRIDGE_BUILD_TESTING`; counter member under same gate |
+| `udp_bridge/src/connection.cpp` | Increment counter at entry of `resend_packets` (gated) |
+| `udp_bridge/test/test_remote_node_resend.cpp` | Two new `TEST_F`s: matched-id routing; unknown-id no-op |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Behavior change is opt-out at deployment level (coordinated redeploy); resend volume drop is observable through existing `DataRates.*_bytes_per_second` per connection |
+| A change includes its consequences | Wire-format change → `ResendRequest.msg` comment documents the redeploy contract; no out-of-package consumers (internal control plane); unit test lands with the change |
+| Only what's needed | No config knob, no fallback branch; ~80 LOC plus test |
+| Test what breaks | Unit test asserts routing on the exact decision the field storm exposed; counter seam keeps it deterministic |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Plan committed from worktree `feature/issue-23` |
+| 0008 — ROS 2 official conventions | Yes | Additive trailing field on `ResendRequest.msg` is the conventional pattern; documenting the CDR coordinated-redeploy caveat (matching `MessageInternal.msg`'s existing comment) is the honest version of "ROS message defaults" |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `ResendRequest.msg` (interface) | Downstream consumers | Yes — verified: no external consumers; internal control-plane only |
+| Resend fan-out behavior | Bench harness | Deferred: follow-up comment on #18, not blocking |
+| `decodeResendRequest` routing | Tests covering the routing | Yes — two new `TEST_F`s |
+| Connection method (`resend_packets`) instrumentation | Connection's other test helpers | No new accessor needed beyond the counter; matches existing seam pattern |
+
+## Open Questions
+
+None for implementation — the three design forks are settled. One operational
+note: when this lands, bizzy and operator must be redeployed together. Capture
+in the PR body so it's visible to whoever cuts the deployment.
+
+## Estimated Scope
+
+Single PR. ~80 LOC code + ~50 LOC test. Comparable to the resend-loop work in
+PR #13.

--- a/.agent/work-plans/issue-23/plan.md
+++ b/.agent/work-plans/issue-23/plan.md
@@ -211,3 +211,38 @@ PR #13.
   Promoted to WARN on first miss per id (state bookkeeping in a small
   set on RemoteNode), DEBUG on subsequent — surfaces real config
   errors without spamming during legitimate CONNECT-cycle races.
+
+- **Receive-side connection-id clamp (round-3 fix).** Copilot's PR-25
+  review flagged that `RemoteNode::dispatch_miss_warned_ids_` is
+  populated from a network-supplied string with no enforced upper
+  bound. The send side already truncates to
+  `maximum_connection_id_size - 1` (the sender-stamp truncation
+  introduced in round-2 above), but the receive side did no
+  validation — `ResendRequest.msg` declares `string connection_id`
+  unbounded. Two failure modes followed: (a) memory growth of the
+  WARN-once bookkeeping set under sustained corrupted-but-
+  deserializable packets or a misbehaving peer; (b) silent
+  resend-routing miss for any older or buggy peer that didn't apply
+  the truncation contract (its full-length id would never match the
+  truncated key in `connections_`). Round-3 fix: clamp
+  `rr.connection_id` to `maximum_connection_id_size - 1` in
+  `decodeResendRequest` right after the deserialize, mirroring the
+  sender-side `assign(..., 0, maximum_connection_id_size - 1)` at
+  `udp_bridge.cpp:1034-1035`. The clamp is a one-line invariant; the
+  existing `DispatchHonorsTruncatedConnectionId` test already covers
+  the downstream behavior the clamp leans on (truncated-form lookup
+  matches; untruncated misses). A dedicated test for the clamp itself
+  would require exposing the private `decodeResendRequest` or
+  refactoring it into a free helper, which is disproportionate for a
+  one-line resize on a value field.
+
+- **Doc-comment + test-name polish (round-3).** Two stale-wording
+  findings from the same Copilot review: the `dispatchResendRequest`
+  header comment in `remote_node.h` still said "emit a DEBUG log" even
+  though round-2 promoted it to WARN-first/DEBUG-subsequent; updated
+  to match the impl. And two dispatch-miss tests in
+  `test_remote_node_resend.cpp` were named `DispatchSilentlyDrops*`
+  with prose saying "must no-op silently", which wrongly implied no
+  diagnostic output. Renamed to `DispatchDropsWithoutBroadcast*` and
+  reworded the surrounding comments — the invariant under test is
+  "no broadcast fallback," not "no log output."

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 23
+---
+
+# Issue #23 — Restrict resend response to the connection the request arrived on (add connection_id to ResendRequest)
+
+## External Review
+**Status**: complete
+**When**: 2026-05-20 16:54
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #25 — 1 review (Copilot), 5 inline comments: 2 valid, 1 false positive, 2 borderline (surface to user)
+**CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4)
+
+### Actions
+- [ ] Fix `udp_bridge/include/udp_bridge/remote_node.h:63–72` — doc comment claims `dispatchResendRequest` logs at DEBUG on lookup miss, but the impl in `remote_node.cpp:186–199` emits WARN on first-miss-per-id and DEBUG on subsequent. Update the comment to match (mirror the existing field comment at `remote_node.h:177–183`).
+- [ ] Rename and reword "silently drops" tests in `udp_bridge/test/test_remote_node_resend.cpp` — tests `DispatchSilentlyDropsWhenStampedIdAbsent` (line 533) and `DispatchSilentlyDropsUnknownConnectionId` (line 555), plus the comment at lines 531–532 ("Dispatch must no-op silently"), wrongly imply no diagnostic output. The invariant is "no broadcast fallback," not "no log." Rename to `DispatchDropsWithoutBroadcast…` and reword the comments.
+- [ ] Decide (surface to user): clamp incoming `rr.connection_id` to `maximum_connection_id_size - 1` (8-byte) at the receive side in `udp_bridge.cpp:decodeResendRequest`. Closes the latent unbounded-growth of `dispatch_miss_warned_ids_` from a misbehaving peer AND aligns the receive side with the existing sender-side truncation contract. Existing comment at `remote_node.h:181–183` documents the current "trust the peer config space" tradeoff — user picks.
+- [ ] (Optional) On PR #25, reply to or dismiss the CMake/ODR Copilot finding (false positive — the existing `UDP_BRIDGE_BUILD_TESTING` namespacing in `CMakeLists.txt:67–94` is exactly the mitigation Copilot recommended; no downstream consumers currently include `udp_bridge/connection.h`).

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -232,7 +232,7 @@ Round-9 changes addressing all three valid Copilot findings from the PR #25 tria
 - **`udp_bridge/src/udp_bridge.cpp`** — dropped the hard-coded `"udp_bridge.cpp:568-614"` line range from the `decodeResendRequest` comment block. The outer `UDPBridge::decode` catch-all is actually at lines 707–715 inside the function at 647, so the range was already wrong.
 
 ## External Review
-**Status**: needs-discussion
+**Status**: complete (resolved by round-10 below)
 **When**: 2026-05-21 13:55
 **By**: Claude Code Agent (Claude Opus 4.7 (1M context))
 
@@ -252,8 +252,24 @@ This argument assumes the receiver's `connections_` is keyed on the truncated wi
 **Mitigating context (why this isn't a live-loss bug today)**: current production configs in `unh_echoboats_project11/izzyboat_project11/config/{izzyboat,operator}.yaml` use connection ids `"wifi"` (4 chars) and `"vpn"` (3 chars). No production config in this branch has an id ≥8 chars. The contract gap is latent, not actively breaking field resends. But the team has discussed Starlink-named links (see workspace memory on link calibration); a future config that names an id "starlink" or similar would silently lose resend recovery on that link.
 
 ### Actions
-- [ ] **Decision needed**: scope of fix for PR #25 vs follow-up. Three options:
+- [x] **Decision**: user picked (a) — fix in PR #25 by canonicalizing. Implemented in round-10 below. Three options that were on the table:
   - **(a) In scope for PR #25**: canonicalize ids to the 7-char wire form at every insertion point (param ingestion, `RemoteNode::update(Remote)`, `RemoteNode::update(BridgeInfo)`, `unwrap()`, CONNECT path); reject collisions at config time; add a wire-contract integration test (a real `WrappedPacket` round-trip — neither sender truncation nor receive-side clamp has a unit test today, by design per the round-8 scope note).
   - **(b) Follow-up issue**: file a sequel to #23 with both Copilot citations + the BridgeInfo/unwrap analysis above; close R8 threads with a link to the new issue so the signal isn't lost.
   - **(c) Documented invariant**: accept "configured ids must be ≤7 chars" as a hard rule. Add a runtime check at param ingestion that rejects/warns on ids ≥8 chars; update the field comment on `dispatch_miss_warned_ids_` to state the invariant; **fix the round-8 scope-note in `test_remote_node_resend.cpp:600-617`** — it's currently asserting a contract that doesn't hold.
-- [ ] (Optional) Dismiss the stale R1–R7 Copilot threads in the GitHub UI.
+- [ ] (Optional) Dismiss the stale R1–R8 Copilot threads in the GitHub UI.
+
+## Address External Review
+**Status**: complete
+**When**: 2026-05-21 14:35
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Round-10 changes implementing option (a) for Copilot R8's truncation-contract finding: canonicalize all connection ids to the on-wire truncated form at every connections_ insertion / lookup point. After the change, `connection->id()`, `connections_` keys, and the on-wire stamp always agree on a single canonical form (first `maximum_connection_id_size - 1` bytes), so a ResendRequest stamped with the wire form always lands on the connection that holds `sent_packets_` for the link — even for configured ids ≥ 8 chars.
+
+- **`udp_bridge/include/udp_bridge/packet.h`** — new `truncate_connection_id(const std::string&)` helper. Single source of truth for the canonical form.
+- **`udp_bridge/src/connection.cpp`** — `Connection::Connection` canonicalizes `id_` in its initializer so `connection->id()` is always canonical.
+- **`udp_bridge/src/remote_node.cpp`** — `newConnection` canonicalizes its input and emits a one-time WARN when truncation actually shortens (surfaces the change at startup; flags the collision risk for any two configured ids sharing the first 7 chars). `connection()` canonicalizes its lookup id so callers can pass either form.
+- **`udp_bridge/src/udp_bridge.cpp`** — updated comments on the sender-side stamp (now a defensive no-op since `connection->id()` is canonical) and the receive-side clamp (now a defense against misbehaving peers rather than the primary canonicalization mechanism).
+- **`udp_bridge/include/udp_bridge/remote_node.h`** — field comment on `dispatch_miss_warned_ids_` updated to reflect the new contract.
+- **`udp_bridge/test/test_remote_node_resend.cpp`** — new `NewConnectionCanonicalizesLongId` test exercises the contract end-to-end. Scope note above `DispatchDoesNotFuzzyMatchConnectionId` rewritten — the wire-decode clamp is no longer the primary canonicalization mechanism, the connections_ insertion sites are. Routing-section header updated to "Six tests below…" with the new canonicalization bullet.
+
+Build clean, full suite green (83 tests, +1 vs round-9). New test verified with direct gtest filter — both the WARN-on-truncation and the canonical-form routing assertions fire.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -230,3 +230,30 @@ Round-9 changes addressing all three valid Copilot findings from the PR #25 tria
 - **`udp_bridge/test/test_remote_node_resend.cpp`** — rewrote the routing-section block comment to enumerate all five tests by their current names. The pre-round-8 `TruncatedConnectionIdMatches` bullet was still present even though the test had been renamed to `DispatchDoesNotFuzzyMatchConnectionId` in round-8. New bullet describes what the renamed test actually verifies (dispatch strict-equality, not the wire-contract truncation that lives in private receive plumbing).
 - **`udp_bridge/include/udp_bridge/remote_node.h`** — dropped the hard-coded `"see udp_bridge.cpp around line 715"` from the `dispatch_miss_warned_ids_` field comment. `UDPBridge::decodeResendRequest` is already named there, so the line reference is redundant and was already drifted (actual clamp is at udp_bridge.cpp:847 post-merge).
 - **`udp_bridge/src/udp_bridge.cpp`** — dropped the hard-coded `"udp_bridge.cpp:568-614"` line range from the `decodeResendRequest` comment block. The outer `UDPBridge::decode` catch-all is actually at lines 707–715 inside the function at 647, so the range was already wrong.
+
+## External Review
+**Status**: needs-discussion
+**When**: 2026-05-21 13:55
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #25 — 8 review(s) (all Copilot, no human), 20 inline comments total; 2 new on R8 (against `20e67cb`), both substantive and **not addressed**
+**CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4)
+
+R8 raised two views of one underlying contract gap. Both **valid** and **substantive** (not comment drift):
+
+- `udp_bridge/src/udp_bridge.cpp:1173` and `udp_bridge/src/remote_node.cpp:149`: **The truncation contract is one-sided.** Sender truncates `rr.connection_id` to 7 chars (`maximum_connection_id_size - 1`). Receiver's `connections_` map, however, is populated from BridgeInfo (`rc.connection_id = connection->id();` at `udp_bridge.cpp:1474` — **full configured id**) and from config — never canonicalized to the 7-char wire form. The duplicate "starlin" entry created by `unwrap()` on packet arrival is what `dispatchResendRequest` actually finds. That duplicate connection's `sent_packets_` is empty (the real sends went through the "starlink" connection). Resend response is silently empty for any configured id ≥8 chars.
+
+The round-8 self-review explicitly stated a contract that turns out not to hold. `test_remote_node_resend.cpp:600-617` (the scope note above `DispatchDoesNotFuzzyMatchConnectionId`) says:
+
+> "A regression that re-introduces the pre-fix bug (sender stamps the full untruncated id) would still route correctly today because the receive-side clamp would normalize the id before reaching dispatch."
+
+This argument assumes the receiver's `connections_` is keyed on the truncated wire form. The BridgeInfo population path keeps the full configured id. Test setup at line 623 (`newConnection("starlin", ...)`) doesn't mirror production where the map would also contain "starlink" from BridgeInfo.
+
+**Mitigating context (why this isn't a live-loss bug today)**: current production configs in `unh_echoboats_project11/izzyboat_project11/config/{izzyboat,operator}.yaml` use connection ids `"wifi"` (4 chars) and `"vpn"` (3 chars). No production config in this branch has an id ≥8 chars. The contract gap is latent, not actively breaking field resends. But the team has discussed Starlink-named links (see workspace memory on link calibration); a future config that names an id "starlink" or similar would silently lose resend recovery on that link.
+
+### Actions
+- [ ] **Decision needed**: scope of fix for PR #25 vs follow-up. Three options:
+  - **(a) In scope for PR #25**: canonicalize ids to the 7-char wire form at every insertion point (param ingestion, `RemoteNode::update(Remote)`, `RemoteNode::update(BridgeInfo)`, `unwrap()`, CONNECT path); reject collisions at config time; add a wire-contract integration test (a real `WrappedPacket` round-trip — neither sender truncation nor receive-side clamp has a unit test today, by design per the round-8 scope note).
+  - **(b) Follow-up issue**: file a sequel to #23 with both Copilot citations + the BridgeInfo/unwrap analysis above; close R8 threads with a link to the new issue so the signal isn't lost.
+  - **(c) Documented invariant**: accept "configured ids must be ≤7 chars" as a hard rule. Add a runtime check at param ingestion that rejects/warns on ids ≥8 chars; update the field comment on `dispatch_miss_warned_ids_` to state the invariant; **fix the round-8 scope-note in `test_remote_node_resend.cpp:600-617`** — it's currently asserting a contract that doesn't hold.
+- [ ] (Optional) Dismiss the stale R1–R7 Copilot threads in the GitHub UI.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -127,3 +127,16 @@ Round-6 changes addressing Copilot's review-4 polish findings:
 - **`.agent/work-plans/issue-23/plan.md`** — round-6 implementation note documenting all three changes.
 
 Build and full test suite (51 tests) green locally on the worktree.
+
+## External Review
+**Status**: complete
+**When**: 2026-05-20 19:25
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #25 (after round-6 push) — 5 reviews (Copilot). Reviews 1–4 status unchanged. Review 5 against current HEAD `f7d5977` adds 2 comments — same finding presented twice (one on the `.msg` file, one on the C++ decode site).
+**CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4)
+
+The finding: round-3's try/catch comment in `decodeResendRequest` (and the matching wording in `ResendRequest.msg`) overstates the benefit. Both comments claim that without the local try/catch a deserialization exception would propagate to the executor and kill the bridge. Verified false: `UDPBridge::decode()` at `udp_bridge.cpp:568-614` already has an outer catch-all around every `decode*` call (`decodeResendRequest` is invoked at line 596-598). The inner try/catch's actual benefit is diagnostic — it emits a specific WARN naming the source (node_name, host, port) and the failure kind, instead of falling through to the outer's generic "decoding error on packet of type N" ERROR. Useful for operators chasing a coordinated-redeploy mismatch, but not load-bearing for executor survival.
+
+### Actions
+- [ ] Fix #12 + #13 (bundle): update the inner try/catch comment in `udp_bridge.cpp` and the matching note in `ResendRequest.msg` to describe the real benefit (specific WARN vs generic ERROR; site-specific diagnostic) and explicitly note that executor survival is the outer catch's responsibility, not this one. Comment-only.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -61,3 +61,23 @@ Round-4 changes addressing Copilot's review-2 sharpening of the unbounded-set co
 Build and full test suite (51 tests; +1 cap test) green locally on the worktree.
 
 CMake/ODR Copilot finding still standing as documented false positive.
+
+## External Review
+**Status**: complete
+**When**: 2026-05-20 18:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #25 (after round-4 push) — 3 reviews (Copilot). Review 1 (against stale `e244b9b`) and Review 2 (against `f6dad12`) status unchanged; Review 3 against current HEAD `5225c2e` adds 2 new findings, both valid.
+**CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4)
+
+Two new findings:
+
+1. **`remote_node.h:13`** — `<set>` include removed in round-4 (set was only used for the now-replaced `dispatch_miss_warned_ids_`), but `given_up_packet_numbers_` at line 260 still uses `std::set<uint64_t>`. Build succeeds only because `udp_bridge.h:10` transitively brings `<set>` in. Fragile.
+2. **`CMakeLists.txt:95`** — when `BUILD_TESTING=ON`, the library is compiled with `UDP_BRIDGE_BUILD_TESTING` (larger `Connection`/`RemoteNode` layouts), but the `udp_bridge_node` executable target links against that library without defining the same macro. Its compilation of `connection.h`/`remote_node.h` (via `udp_bridge.h:25`) sees the smaller layouts. In-package ODR mismatch. In practice the executable doesn't allocate `Connection` by value or inline layout-dependent methods (everything goes through `shared_ptr` and out-of-line library methods), so it hasn't bitten us — but it's UB per the standard.
+
+Updates the prior classification: the original CMake/ODR finding from Review 1 was directionally correct on the principle; I covered downstream-package consumers but missed the in-package executable consumer. Reclassifying that comment from false-positive to partially-valid.
+
+### Actions
+- [ ] Fix #7: re-add `#include <set>` to `udp_bridge/include/udp_bridge/remote_node.h` alongside `<deque>` and `<unordered_set>`.
+- [ ] Fix #8: add `target_compile_definitions(udp_bridge_node PRIVATE UDP_BRIDGE_BUILD_TESTING)` inside the existing `if(BUILD_TESTING)` block in `CMakeLists.txt`. Extend the CMake comment to cover the in-package executable case alongside the existing downstream-package wording.
+- [ ] Update `plan.md` round-5 note documenting both fixes and the partial-false-positive correction.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -43,5 +43,21 @@ CMake/ODR Copilot finding left as-is; existing `UDP_BRIDGE_BUILD_TESTING` namesp
 **CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4)
 
 ### Actions
-- [ ] Decide between (a) comment-only honesty fix on `remote_node.h:184–189`'s `dispatch_miss_warned_ids_` field comment — drop "bounded by the configuration space ... which is small" and replace with the actual trust-model assumption — or (b) hard cap / LRU eviction on the set (~8 LOC + test) so the code enforces what the comment promises. Recommend (b) this round — bot has flagged this concern twice; an LRU cap is small and stops the re-review treadmill.
+- [x] User decision 2026-05-20: option (b). Bounded FIFO with eviction added in round-4 (see entry below).
 - [ ] (Optional) On PR #25, dismiss or reply to the #4 (CMake/ODR) Copilot finding so it stops reappearing in future reviews.
+
+## Address External Review
+**Status**: complete
+**When**: 2026-05-20 17:47
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Round-4 changes addressing Copilot's review-2 sharpening of the unbounded-set concern:
+
+- **`udp_bridge/include/udp_bridge/remote_node.h`** — replaced `std::set<std::string> dispatch_miss_warned_ids_` with a bounded FIFO: `std::deque<std::string> dispatch_miss_warned_order_` (insertion order) plus `std::unordered_set<std::string> dispatch_miss_warned_ids_` (O(1) presence checks), capped at `static constexpr std::size_t kDispatchMissWarnedCap = 256`. Field comment rewritten to describe what's now actually enforced. Added `dispatchMissWarnedIdCountForTest()` accessor under `UDP_BRIDGE_BUILD_TESTING`.
+- **`udp_bridge/src/remote_node.cpp`** — `dispatchResendRequest` updated to use the bounded FIFO: presence check via `unordered_set::count`; on insertion-past-cap, evict from the front of the deque and the corresponding entry from the set. New test accessor implemented (returns `dispatch_miss_warned_ids_.size()` under `state_mutex_`).
+- **`udp_bridge/test/test_remote_node_resend.cpp`** — new `DispatchMissWarnedIdsAreBounded` test pushes 1024 distinct ids through `dispatchResendRequest` (no connections registered, so all are lookup-misses by construction) and asserts `dispatchMissWarnedIdCountForTest()` returns `<= 512` (generous upper bound on the cap), `< 1024` (proves the cap fires), and `>= 1` (proves the WARN-once path is reached). Test name and assertions are written against the observable cap behavior, not a specific cap value — cap value is an implementation choice, not a wire contract.
+- **`.agent/work-plans/issue-23/plan.md`** — added round-4 implementation note describing the FIFO+set design, eviction semantics, and cap rationale.
+
+Build and full test suite (51 tests; +1 cap test) green locally on the worktree.
+
+CMake/ODR Copilot finding still standing as documented false positive.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -94,3 +94,22 @@ Round-5 changes addressing Copilot's review-3 findings (against round-4 HEAD `52
 - **`.agent/work-plans/issue-23/plan.md`** — round-5 implementation note documenting both fixes and the corrected classification.
 
 Build and full test suite (51 tests) green locally on the worktree.
+
+## External Review
+**Status**: complete
+**When**: 2026-05-20 18:30
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #25 (after round-5 push) — 4 reviews (Copilot). Reviews 1–3 status unchanged (all earlier findings addressed in rounds 2–5). Review 4 against current HEAD `3f40162` adds 3 new findings, all valid polish items.
+**CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4 on `5225c2e`; new run for `3f40162` not yet queued at triage time)
+
+Three new findings:
+
+1. **`udp_bridge/src/udp_bridge.cpp:716-732`** — receive-side clamp rationale comment claims `dispatch_miss_warned_ids_` "is never pruned" as part of gap #2's framing. Round-4 added FIFO eviction with cap `kDispatchMissWarnedCap`, so the table IS pruned now. The clamp itself still pays off (bounds per-entry size to 7 bytes, aligns wire contract for older/buggy peers), but the "ties the practical bound to the configured id space" wording is stale.
+2. **`udp_bridge/test/test_remote_node_resend.cpp:666`** — `DispatchMissWarnedIdsAreBounded` pushes 1024 distinct ids through dispatch, each emitting a WARN-on-first-miss log line. The captured test log carries ~1024 WARN lines per run. Doesn't affect pass/fail but is CI-noisy.
+3. **`udp_bridge/src/remote_node.cpp:201-206`** — `joined` string and `known_ids` join loop are built unconditionally on every lookup miss, even when the message will only log at DEBUG. Typically 2–4 known ids so the wasted work is small, but it's avoidable.
+
+### Actions
+- [ ] Fix #9: tighten the clamp rationale comment in `udp_bridge.cpp:716–732` to reflect the round-4 FIFO cap (mention the cap+eviction; keep the per-entry-size and older-peer rationales).
+- [ ] Fix #10: reduce `DispatchMissWarnedIdsAreBounded`'s push count to `kDispatchMissWarnedCap + 32` and raise the logger level inside the test to silence the WARN spam (restore on exit).
+- [ ] Fix #11: move the `joined` build into the WARN branch only; simplify the DEBUG-branch message to reference the prior WARN, since the WARN already showed the known_ids list.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -78,6 +78,19 @@ Two new findings:
 Updates the prior classification: the original CMake/ODR finding from Review 1 was directionally correct on the principle; I covered downstream-package consumers but missed the in-package executable consumer. Reclassifying that comment from false-positive to partially-valid.
 
 ### Actions
-- [ ] Fix #7: re-add `#include <set>` to `udp_bridge/include/udp_bridge/remote_node.h` alongside `<deque>` and `<unordered_set>`.
-- [ ] Fix #8: add `target_compile_definitions(udp_bridge_node PRIVATE UDP_BRIDGE_BUILD_TESTING)` inside the existing `if(BUILD_TESTING)` block in `CMakeLists.txt`. Extend the CMake comment to cover the in-package executable case alongside the existing downstream-package wording.
-- [ ] Update `plan.md` round-5 note documenting both fixes and the partial-false-positive correction.
+- [x] Fix #7: re-add `#include <set>` to `udp_bridge/include/udp_bridge/remote_node.h` alongside `<deque>` and `<unordered_set>`.
+- [x] Fix #8: add `target_compile_definitions(udp_bridge_node PRIVATE UDP_BRIDGE_BUILD_TESTING)` inside the existing `if(BUILD_TESTING)` block in `CMakeLists.txt`. Extend the CMake comment to cover the in-package executable case alongside the existing downstream-package wording.
+- [x] Update `plan.md` round-5 note documenting both fixes and the partial-false-positive correction.
+
+## Address External Review
+**Status**: complete
+**When**: 2026-05-20 18:05
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Round-5 changes addressing Copilot's review-3 findings (against round-4 HEAD `5225c2e`):
+
+- **`udp_bridge/include/udp_bridge/remote_node.h`** — added `#include <set>` alongside the existing `<deque>` and `<unordered_set>`. `given_up_packet_numbers_` at line 260 still uses `std::set<uint64_t>`; without the direct include the build was relying on a transitive include via `udp_bridge.h:10`. Fragile.
+- **`udp_bridge/CMakeLists.txt`** — added `target_compile_definitions(udp_bridge_node PRIVATE UDP_BRIDGE_BUILD_TESTING)` inside the existing `if(BUILD_TESTING)` block, with a new comment paragraph explaining why the in-package executable needs the same discipline as the test targets (the executable includes `udp_bridge.h` which directly includes `connection.h`, so it sees `Connection`'s class definition; without the macro it would compile against a different layout than the library was built with). Walks back my earlier "false positive" classification on the original CMake/ODR finding from review 1 — the in-package executable was the consumer I'd failed to audit.
+- **`.agent/work-plans/issue-23/plan.md`** — round-5 implementation note documenting both fixes and the corrected classification.
+
+Build and full test suite (51 tests) green locally on the worktree.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -33,3 +33,15 @@ Round-3 changes addressing Copilot's PR-25 review:
 Build and full test suite (50 tests) green locally on the worktree.
 
 CMake/ODR Copilot finding left as-is; existing `UDP_BRIDGE_BUILD_TESTING` namespacing in `CMakeLists.txt:67–94` already addresses it.
+
+## External Review
+**Status**: complete
+**When**: 2026-05-20 17:30
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #25 (after round-3 push) — 2 reviews (Copilot), 6 inline comments total. Of the 5 from review 1 (stale, against `e244b9b`): 3 addressed by round-3 (#1 doc, #5 test rename, #2/#3 partially via clamp), 1 standing-by false positive (#4 CMake/ODR), 1 still open. Review 2 (against current HEAD `f6dad12`) adds 1 new comment sharpening the unbounded-set concern: the receive-side clamp bounds per-entry size but not the count of distinct ids.
+**CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4)
+
+### Actions
+- [ ] Decide between (a) comment-only honesty fix on `remote_node.h:184–189`'s `dispatch_miss_warned_ids_` field comment — drop "bounded by the configuration space ... which is small" and replace with the actual trust-model assumption — or (b) hard cap / LRU eviction on the set (~8 LOC + test) so the code enforces what the comment promises. Recommend (b) this round — bot has flagged this concern twice; an LRU cap is small and stops the re-review treadmill.
+- [ ] (Optional) On PR #25, dismiss or reply to the #4 (CMake/ODR) Copilot finding so it stops reappearing in future reviews.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -139,4 +139,17 @@ Build and full test suite (51 tests) green locally on the worktree.
 The finding: round-3's try/catch comment in `decodeResendRequest` (and the matching wording in `ResendRequest.msg`) overstates the benefit. Both comments claim that without the local try/catch a deserialization exception would propagate to the executor and kill the bridge. Verified false: `UDPBridge::decode()` at `udp_bridge.cpp:568-614` already has an outer catch-all around every `decode*` call (`decodeResendRequest` is invoked at line 596-598). The inner try/catch's actual benefit is diagnostic — it emits a specific WARN naming the source (node_name, host, port) and the failure kind, instead of falling through to the outer's generic "decoding error on packet of type N" ERROR. Useful for operators chasing a coordinated-redeploy mismatch, but not load-bearing for executor survival.
 
 ### Actions
-- [ ] Fix #12 + #13 (bundle): update the inner try/catch comment in `udp_bridge.cpp` and the matching note in `ResendRequest.msg` to describe the real benefit (specific WARN vs generic ERROR; site-specific diagnostic) and explicitly note that executor survival is the outer catch's responsibility, not this one. Comment-only.
+- [x] Fix #12 + #13 (bundle): updated both the inner try/catch comment in `udp_bridge.cpp:697-712` and the matching note in `ResendRequest.msg` to describe the real benefit (site-specific WARN vs outer's generic ERROR) and explicitly note that executor survival comes from `UDPBridge::decode`'s outer catch-all, not this site-specific one. Comment-only change; build + 51/0/0 tests green.
+
+## Address External Review
+**Status**: complete
+**When**: 2026-05-20 19:35
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Round-7 changes addressing Copilot's review-5 (same finding presented twice):
+
+- **`udp_bridge/src/udp_bridge.cpp:697-712`** — rewrote the inner try/catch rationale to describe the actual contract: diagnostic clarity (site-specific WARN naming source bridge + failure kind) vs the outer catch-all's generic "decoding error on packet of type N" ERROR. Explicitly notes that executor survival comes from the outer catch in `UDPBridge::decode` (line 568-614), not this one. The follow-up note about other `decode*` sites was also softened — mirroring the pattern is a diagnostic-payoff judgment call, not a survival requirement.
+- **`udp_bridge_interfaces/msg/ResendRequest.msg`** — matched the corrected framing on the message side: site-specific catch is about diagnosability of the coordinated-redeploy scenario, not survival; survival is provided by the outer catch in `UDPBridge::decode`.
+- **`.agent/work-plans/issue-23/plan.md`** — round-7 implementation note documenting the correction.
+
+Build and full test suite (51 tests) green locally on the worktree.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -166,9 +166,9 @@ Build and full test suite (51 tests) green locally on the worktree.
 **Must-fix**: 2 | **Suggestions**: 10
 
 ### Findings
-- [ ] (must-fix) `DispatchHonorsTruncatedConnectionId` bypasses the receive-side clamp — test asserts a false invariant about wire-contract behavior — `udp_bridge/test/test_remote_node_resend.cpp:597-632`
-- [ ] (must-fix) WARN message claims "Further misses for this id will log at DEBUG" but FIFO eviction can re-WARN — comment-vs-code drift — `udp_bridge/src/remote_node.cpp:222`
-- [ ] (suggestion) `DispatchMissWarnedIdsAreBounded` ceiling 512 too loose vs cap 256; also no FIFO-order assertion — `udp_bridge/test/test_remote_node_resend.cpp:700`
+- [x] (must-fix) `DispatchHonorsTruncatedConnectionId` bypasses the receive-side clamp — test asserts a false invariant about wire-contract behavior — `udp_bridge/test/test_remote_node_resend.cpp:597-632`
+- [x] (must-fix) WARN message claims "Further misses for this id will log at DEBUG" but FIFO eviction can re-WARN — comment-vs-code drift — `udp_bridge/src/remote_node.cpp:222`
+- [x] (suggestion) `DispatchMissWarnedIdsAreBounded` ceiling 512 too loose vs cap 256; also no FIFO-order assertion — `udp_bridge/test/test_remote_node_resend.cpp:700`
 - [ ] (suggestion) Receive-side clamp can route a malformed id to a valid connection by prefix-truncation; document this in the clamp comment — `udp_bridge/src/udp_bridge.cpp:~733`
 - [ ] (suggestion) `dispatchResendRequest` is public on RemoteNode but only one production caller; either mark "public for test access only; production callers must clamp first" or make private+friend — `udp_bridge/include/udp_bridge/remote_node.h:65-86`
 - [ ] (suggestion) Field comment line-number drift: refers to clamp "around line 715" but the clamp is now at ~733 post-merge — `udp_bridge/include/udp_bridge/remote_node.h:~202`
@@ -178,3 +178,30 @@ Build and full test suite (51 tests) green locally on the worktree.
 - [ ] (suggestion) Test logger level restore preserves prior-test state; cheap to add a comment noting this is deliberate — `udp_bridge/test/test_remote_node_resend.cpp:668-688`
 - [ ] (suggestion) WARN known_ids list uses bare comma join; would parse ambiguously if any future id contained a comma. Quote each id — `udp_bridge/src/remote_node.cpp:~226`
 - [ ] (suggestion) `rr.connection_id.resize()` doesn't shrink_to_fit; bounded (rr is stack-local) but the field-comment "table-entry-size" argument depends on copies normalizing capacity. Add note or call shrink_to_fit — `udp_bridge/src/udp_bridge.cpp:~734`
+
+## Address External Review
+**Status**: complete
+**When**: 2026-05-20 21:50
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Round-8 changes addressing the two must-fixes (and suggestion #3) from the local `/review-code` pass:
+
+- **`udp_bridge/test/test_remote_node_resend.cpp`** — renamed `DispatchHonorsTruncatedConnectionId` to `DispatchDoesNotFuzzyMatchConnectionId` and rewrote the comment block to be honest about what the test actually verifies (dispatch strict-equality, no fuzzy-match) and what it does NOT verify (the wire contract — sender truncation + receive clamp — which lives in the private wire-decode plumbing of `UDPBridge`). The previous comment block falsely claimed this test caught wire-contract regressions; post-round-3 it didn't, because the receive-side clamp would normalize an unclamped 8-char id before reaching dispatch.
+- **`udp_bridge/src/remote_node.cpp`** — WARN message at line 222 reworded to acknowledge that FIFO eviction can re-fire the WARN: "Further misses for this id will log at DEBUG (until the rate-limit table evicts this id under pressure, at which point the WARN re-fires on next sighting)." Aligns the user-facing string with the field comment's documented design.
+- **`udp_bridge/test/test_remote_node_resend.cpp`** — `DispatchMissWarnedIdsAreBounded` ceiling tightened from `EXPECT_LE(count, 512u)` to `EXPECT_EQ(count, dispatchMissWarnedCapForTest())` (via a new public static accessor on `RemoteNode` that returns `kDispatchMissWarnedCap` without exposing the private constant). Added a FIFO-order assertion using a new `isDispatchMissWarnedForTest(const std::string&)` accessor: after pushing >cap distinct ids, the most-recently-pushed id MUST still be in the bookkeeping and the earliest-pushed id MUST have been evicted. Catches a regression that evicts LIFO or arbitrarily.
+- **`udp_bridge/include/udp_bridge/remote_node.h`** — added `isDispatchMissWarnedForTest(const std::string&)` and `dispatchMissWarnedCapForTest()` accessors under `UDP_BRIDGE_BUILD_TESTING`. Both follow the existing test-accessor pattern.
+- **`udp_bridge/src/remote_node.cpp`** — added the `isDispatchMissWarnedForTest` implementation under the same gate.
+- **`.agent/work-plans/issue-23/plan.md`** — round-8 implementation note documenting the self-review must-fixes and the suggestion tightening.
+
+Build and full test suite (82 tests; +0 vs round-7 — same count, renamed test) green locally on the worktree.
+
+Remaining suggestions from the local review (none must-fix; defer to follow-up if needed):
+- Clamp comment doesn't surface prefix-truncation misroute behavior.
+- `dispatchResendRequest` is public on `RemoteNode`; consider marking "public for test access only".
+- Field-comment line-number reference drift ("around line 715" → 847).
+- Audit other in-package `add_executable` targets for the `UDP_BRIDGE_BUILD_TESTING` discipline.
+- Per-connection serialize+send CPU-cost tradeoff isn't surfaced in the `resendMissingPackets` comment.
+- `resend_call_count_for_test_` increment isn't atomic.
+- Test logger level restore preserves prior-test state (low risk, by design).
+- WARN known_ids list uses bare comma join (theoretical ambiguity if ids ever contain commas).
+- `rr.connection_id.resize()` doesn't `shrink_to_fit` (bounded; stack-local).

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -273,3 +273,25 @@ Round-10 changes implementing option (a) for Copilot R8's truncation-contract fi
 - **`udp_bridge/test/test_remote_node_resend.cpp`** — new `NewConnectionCanonicalizesLongId` test exercises the contract end-to-end. Scope note above `DispatchDoesNotFuzzyMatchConnectionId` rewritten — the wire-decode clamp is no longer the primary canonicalization mechanism, the connections_ insertion sites are. Routing-section header updated to "Six tests below…" with the new canonicalization bullet.
 
 Build clean, full suite green (83 tests, +1 vs round-9). New test verified with direct gtest filter — both the WARN-on-truncation and the canonical-form routing assertions fire.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-05-21 14:50
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-23 at `0697ee0`
+**Mode**: pre-push
+**Depth**: Deep (reason: 1533 lines, concurrency-sensitive wire-protocol code, new msg field, build-config change)
+**Must-fix**: 2 | **Suggestions**: 7
+
+### Findings
+- [ ] (must-fix) `RemoteNode::update(const Remote&)` uses bare `operator[]` with untruncated id — orphan null entry + Connection-state clobber on repeat calls — `udp_bridge/src/remote_node.cpp:35`
+- [ ] (must-fix) `RemoteNode::newConnection` unconditionally overwrites canonical-key entries — silent collision when two configured ids share first 7 chars — `udp_bridge/src/remote_node.cpp:119`
+- [ ] (suggestion) Stale comment claims connections_ is keyed on "full pre-truncation id from config" — post-R10 it's canonical — `udp_bridge/src/udp_bridge.cpp:1175`
+- [ ] (suggestion) `dispatchResendRequest` raw `connections_.find` — route through canonical `connection()` for defense-in-depth — `udp_bridge/src/remote_node.cpp:146`
+- [ ] (suggestion) `truncate_connection_id` could be `noexcept` + take `std::string_view` to skip copies on no-truncation common path — `udp_bridge/include/udp_bridge/packet.h`
+- [ ] (suggestion) `adoptConnection` keys on `connection->id()` (canonical by transitivity post-R10); add `assert(connection->id() == truncate_connection_id(connection->id()))` to pin the invariant — `udp_bridge/src/remote_node.cpp:128`
+- [ ] (suggestion) Add tests for `update(Remote)` long-id path + collision case (two configured ids sharing first 7 chars) — `udp_bridge/test/test_remote_node_resend.cpp`
+- [ ] (suggestion) Update plan.md "Files to Change" table to include new `packet.h` helper added in round-10 — `.agent/work-plans/issue-23/plan.md`
+- [ ] (suggestion) Verify PR body carries the coordinated-redeploy notice for whoever cuts the deployment (plan flags this as open question) — PR body

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -171,7 +171,7 @@ Build and full test suite (51 tests) green locally on the worktree.
 - [x] (suggestion) `DispatchMissWarnedIdsAreBounded` ceiling 512 too loose vs cap 256; also no FIFO-order assertion — `udp_bridge/test/test_remote_node_resend.cpp:700`
 - [ ] (suggestion) Receive-side clamp can route a malformed id to a valid connection by prefix-truncation; document this in the clamp comment — `udp_bridge/src/udp_bridge.cpp:~733`
 - [ ] (suggestion) `dispatchResendRequest` is public on RemoteNode but only one production caller; either mark "public for test access only; production callers must clamp first" or make private+friend — `udp_bridge/include/udp_bridge/remote_node.h:65-86`
-- [ ] (suggestion) Field comment line-number drift: refers to clamp "around line 715" but the clamp is now at ~733 post-merge — `udp_bridge/include/udp_bridge/remote_node.h:~202`
+- [x] (suggestion) Field comment line-number drift: refers to clamp "around line 715" but the clamp is now at ~733 post-merge — `udp_bridge/include/udp_bridge/remote_node.h:~202` (fixed round-9, also dropped a sibling drift in `udp_bridge.cpp` decodeResendRequest comment that referenced "udp_bridge.cpp:568-614")
 - [ ] (suggestion) Audit other in-package `add_executable` targets and document the `UDP_BRIDGE_BUILD_TESTING` contract — `udp_bridge/CMakeLists.txt:112`
 - [ ] (suggestion) Per-connection serialize+send adds CPU work vs broadcast; mention the tradeoff in the resendMissingPackets comment — `udp_bridge/src/udp_bridge.cpp:~1129-1151`
 - [ ] (suggestion) `resend_call_count_for_test_` increment isn't atomic; document "counter bumps before any I/O" invariant in code or use `std::atomic` — `udp_bridge/src/connection.cpp:~447-449`
@@ -215,7 +215,18 @@ Remaining suggestions from the local review (none must-fix; defer to follow-up i
 **CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4)
 
 ### Actions
-- [ ] Fix `udp_bridge/test/test_remote_node_resend.cpp:461` — block comment says "Four tests below cover…" but the routing section now contains five tests (the bookkeeping-cap test is labeled "Routing case 5" at line 647). Update the count or factor the bookkeeping test into its own header section. (Raised twice — R6 line 476, R7 line 463.)
-- [ ] Fix `udp_bridge/include/udp_bridge/remote_node.h:220–221` — replace hard-coded `"udp_bridge.cpp around line 715"` with a function-name reference (`UDPBridge::decodeResendRequest`). Already on the local-review deferred-suggestion list above; Copilot independently flagged it.
-- [ ] Fix `udp_bridge/src/udp_bridge.cpp:801` — replace hard-coded `"udp_bridge.cpp:568-614"` with `UDPBridge::decode` by name. `decode()` is currently at 647–715 with the catch at 707–715, so the existing range is already wrong.
+- [x] Fix `udp_bridge/test/test_remote_node_resend.cpp:461` — block comment says "Four tests below cover…" but the routing section now contains five tests (the bookkeeping-cap test is labeled "Routing case 5" at line 647). Update the count or factor the bookkeeping test into its own header section. (Raised twice — R6 line 476, R7 line 463.)
+- [x] Fix `udp_bridge/include/udp_bridge/remote_node.h:220–221` — replace hard-coded `"udp_bridge.cpp around line 715"` with a function-name reference (`UDPBridge::decodeResendRequest`). Already on the local-review deferred-suggestion list above; Copilot independently flagged it.
+- [x] Fix `udp_bridge/src/udp_bridge.cpp:801` — replace hard-coded `"udp_bridge.cpp:568-614"` with `UDPBridge::decode` by name. `decode()` is currently at 647–715 with the catch at 707–715, so the existing range is already wrong.
 - [ ] (Optional) Dismiss the stale Copilot review threads (R1–R5, and the R6 finding that R7 superseded) — concerns were resolved by intervening commits but the threads remain marked open in the GitHub UI.
+
+## Address External Review
+**Status**: complete
+**When**: 2026-05-21 03:25
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Round-9 changes addressing all three valid Copilot findings from the PR #25 triage above. Comment-only edits — no behavior change; build clean, full suite green (82 tests, +0 vs round-8).
+
+- **`udp_bridge/test/test_remote_node_resend.cpp`** — rewrote the routing-section block comment to enumerate all five tests by their current names. The pre-round-8 `TruncatedConnectionIdMatches` bullet was still present even though the test had been renamed to `DispatchDoesNotFuzzyMatchConnectionId` in round-8. New bullet describes what the renamed test actually verifies (dispatch strict-equality, not the wire-contract truncation that lives in private receive plumbing).
+- **`udp_bridge/include/udp_bridge/remote_node.h`** — dropped the hard-coded `"see udp_bridge.cpp around line 715"` from the `dispatch_miss_warned_ids_` field comment. `UDPBridge::decodeResendRequest` is already named there, so the line reference is redundant and was already drifted (actual clamp is at udp_bridge.cpp:847 post-merge).
+- **`udp_bridge/src/udp_bridge.cpp`** — dropped the hard-coded `"udp_bridge.cpp:568-614"` line range from the `decodeResendRequest` comment block. The outer `UDPBridge::decode` catch-all is actually at lines 707–715 inside the function at 647, so the range was already wrong.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -110,6 +110,20 @@ Three new findings:
 3. **`udp_bridge/src/remote_node.cpp:201-206`** — `joined` string and `known_ids` join loop are built unconditionally on every lookup miss, even when the message will only log at DEBUG. Typically 2–4 known ids so the wasted work is small, but it's avoidable.
 
 ### Actions
-- [ ] Fix #9: tighten the clamp rationale comment in `udp_bridge.cpp:716–732` to reflect the round-4 FIFO cap (mention the cap+eviction; keep the per-entry-size and older-peer rationales).
-- [ ] Fix #10: reduce `DispatchMissWarnedIdsAreBounded`'s push count to `kDispatchMissWarnedCap + 32` and raise the logger level inside the test to silence the WARN spam (restore on exit).
-- [ ] Fix #11: move the `joined` build into the WARN branch only; simplify the DEBUG-branch message to reference the prior WARN, since the WARN already showed the known_ids list.
+- [x] Fix #9: tighten the clamp rationale comment in `udp_bridge.cpp:716–732` to reflect the round-4 FIFO cap (mention the cap+eviction; keep the per-entry-size and older-peer rationales).
+- [x] Fix #10: reduce `DispatchMissWarnedIdsAreBounded`'s push count to 288 (cap+32) and silence the node logger inside the test (restore on exit). WARN lines from this test dropped from ~1024 to 0.
+- [x] Fix #11: move both the `known_ids` snapshot (inside the lock) and the `joined` build (after the lock) into the WARN branch only; the DEBUG branch now references the prior WARN.
+
+## Address External Review
+**Status**: complete
+**When**: 2026-05-20 18:45
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Round-6 changes addressing Copilot's review-4 polish findings:
+
+- **`udp_bridge/src/udp_bridge.cpp`** — reworded the receive-side clamp rationale to acknowledge round-4's FIFO cap; reframed the clamp's ongoing value (bounds per-entry size; normalizes incoming ids to prevent double-tracking truncated/untruncated forms).
+- **`udp_bridge/src/remote_node.cpp`** — `dispatchResendRequest` now skips the `known_ids` snapshot AND the join loop when the message will only log at DEBUG. The DEBUG message references the prior WARN line for this id ("see the prior WARN line for this id for the known-ids snapshot"). Cap-eviction-induced re-WARNs always carry a fresh `known_ids` list, so the narrative is accurate even under capacity pressure.
+- **`udp_bridge/test/test_remote_node_resend.cpp`** — `DispatchMissWarnedIdsAreBounded` push count reduced from 1024 to 288; node logger temporarily silenced (level set to `Error`) for the duration of the loop, then restored. Verified: captured test log dropped from ~1024 "Dropping ResendRequest" lines to 0 from this test. The cap-enforcement assertion (`dispatchMissWarnedIdCountForTest <= 512`) is unchanged and continues to verify the cap fires.
+- **`.agent/work-plans/issue-23/plan.md`** — round-6 implementation note documenting all three changes.
+
+Build and full test suite (51 tests) green locally on the worktree.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -13,7 +13,23 @@ issue: 23
 **CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4)
 
 ### Actions
-- [ ] Fix `udp_bridge/include/udp_bridge/remote_node.h:63–72` — doc comment claims `dispatchResendRequest` logs at DEBUG on lookup miss, but the impl in `remote_node.cpp:186–199` emits WARN on first-miss-per-id and DEBUG on subsequent. Update the comment to match (mirror the existing field comment at `remote_node.h:177–183`).
-- [ ] Rename and reword "silently drops" tests in `udp_bridge/test/test_remote_node_resend.cpp` — tests `DispatchSilentlyDropsWhenStampedIdAbsent` (line 533) and `DispatchSilentlyDropsUnknownConnectionId` (line 555), plus the comment at lines 531–532 ("Dispatch must no-op silently"), wrongly imply no diagnostic output. The invariant is "no broadcast fallback," not "no log." Rename to `DispatchDropsWithoutBroadcast…` and reword the comments.
-- [ ] Decide (surface to user): clamp incoming `rr.connection_id` to `maximum_connection_id_size - 1` (8-byte) at the receive side in `udp_bridge.cpp:decodeResendRequest`. Closes the latent unbounded-growth of `dispatch_miss_warned_ids_` from a misbehaving peer AND aligns the receive side with the existing sender-side truncation contract. Existing comment at `remote_node.h:181–183` documents the current "trust the peer config space" tradeoff — user picks.
+- [x] Fix `udp_bridge/include/udp_bridge/remote_node.h:63–72` — doc comment claims `dispatchResendRequest` logs at DEBUG on lookup miss, but the impl in `remote_node.cpp:186–199` emits WARN on first-miss-per-id and DEBUG on subsequent. Update the comment to match (mirror the existing field comment at `remote_node.h:177–183`).
+- [x] Rename and reword "silently drops" tests in `udp_bridge/test/test_remote_node_resend.cpp` — tests `DispatchSilentlyDropsWhenStampedIdAbsent` (line 533) and `DispatchSilentlyDropsUnknownConnectionId` (line 555), plus the comment at lines 531–532 ("Dispatch must no-op silently"), wrongly imply no diagnostic output. The invariant is "no broadcast fallback," not "no log." Rename to `DispatchDropsWithoutBroadcast…` and reword the comments.
+- [x] Clamp incoming `rr.connection_id` to `maximum_connection_id_size - 1` (7-byte) at the receive side in `udp_bridge.cpp:decodeResendRequest`. User decision 2026-05-20: option A from the borderline-findings discussion. Closes the latent unbounded-growth of `dispatch_miss_warned_ids_` AND fixes a latent interop gap for older/buggy peers that didn't apply the truncation contract.
 - [ ] (Optional) On PR #25, reply to or dismiss the CMake/ODR Copilot finding (false positive — the existing `UDP_BRIDGE_BUILD_TESTING` namespacing in `CMakeLists.txt:67–94` is exactly the mitigation Copilot recommended; no downstream consumers currently include `udp_bridge/connection.h`).
+
+## Address External Review
+**Status**: complete
+**When**: 2026-05-20 17:25
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Round-3 changes addressing Copilot's PR-25 review:
+
+- **`udp_bridge/src/udp_bridge.cpp`** — `decodeResendRequest` clamps `rr.connection_id` to `maximum_connection_id_size - 1` after the deserialize. Mirrors the sender-side truncation at line 1034-1035. Closes two latent failure modes: unbounded growth of `dispatch_miss_warned_ids_` from network-supplied strings, and silent resend-routing miss for any older/buggy peer that didn't apply the sender-side truncation. No dedicated unit test added: the clamp is a one-line `resize` on a value field, exposing the private `decodeResendRequest` would require a friend declaration or test-only refactor disproportionate to the change, and the existing `DispatchHonorsTruncatedConnectionId` test already covers the downstream truncated-form routing behavior.
+- **`udp_bridge/include/udp_bridge/remote_node.h`** — `dispatchResendRequest` header comment updated to describe WARN-first/DEBUG-subsequent log behavior, matching `remote_node.cpp:186–199` and the field comment at lines 177–183.
+- **`udp_bridge/test/test_remote_node_resend.cpp`** — renamed `DispatchSilentlyDrops…` tests to `DispatchDropsWithoutBroadcast…` and reworded the surrounding "must no-op silently" prose to "no broadcast fallback." Invariant under test is unchanged.
+- **`.agent/work-plans/issue-23/plan.md`** — added two round-3 implementation notes (receive-side clamp; doc/test-name polish).
+
+Build and full test suite (50 tests) green locally on the worktree.
+
+CMake/ODR Copilot finding left as-is; existing `UDP_BRIDGE_BUILD_TESTING` namespacing in `CMakeLists.txt:67–94` already addresses it.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -153,3 +153,28 @@ Round-7 changes addressing Copilot's review-5 (same finding presented twice):
 - **`.agent/work-plans/issue-23/plan.md`** — round-7 implementation note documenting the correction.
 
 Build and full test suite (51 tests) green locally on the worktree.
+
+## Local Review (Post-PR)
+**Status**: complete
+**When**: 2026-05-20 21:37
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+**Verdict**: changes-requested
+
+**PR**: #25 at `3319fcd` (post-jazzy-merge)
+**Mode**: post-PR
+**Depth**: Deep (reason: 1197 added lines, wire-format change, concurrency code, in-package ABI hygiene, network-supplied data)
+**Must-fix**: 2 | **Suggestions**: 10
+
+### Findings
+- [ ] (must-fix) `DispatchHonorsTruncatedConnectionId` bypasses the receive-side clamp — test asserts a false invariant about wire-contract behavior — `udp_bridge/test/test_remote_node_resend.cpp:597-632`
+- [ ] (must-fix) WARN message claims "Further misses for this id will log at DEBUG" but FIFO eviction can re-WARN — comment-vs-code drift — `udp_bridge/src/remote_node.cpp:222`
+- [ ] (suggestion) `DispatchMissWarnedIdsAreBounded` ceiling 512 too loose vs cap 256; also no FIFO-order assertion — `udp_bridge/test/test_remote_node_resend.cpp:700`
+- [ ] (suggestion) Receive-side clamp can route a malformed id to a valid connection by prefix-truncation; document this in the clamp comment — `udp_bridge/src/udp_bridge.cpp:~733`
+- [ ] (suggestion) `dispatchResendRequest` is public on RemoteNode but only one production caller; either mark "public for test access only; production callers must clamp first" or make private+friend — `udp_bridge/include/udp_bridge/remote_node.h:65-86`
+- [ ] (suggestion) Field comment line-number drift: refers to clamp "around line 715" but the clamp is now at ~733 post-merge — `udp_bridge/include/udp_bridge/remote_node.h:~202`
+- [ ] (suggestion) Audit other in-package `add_executable` targets and document the `UDP_BRIDGE_BUILD_TESTING` contract — `udp_bridge/CMakeLists.txt:112`
+- [ ] (suggestion) Per-connection serialize+send adds CPU work vs broadcast; mention the tradeoff in the resendMissingPackets comment — `udp_bridge/src/udp_bridge.cpp:~1129-1151`
+- [ ] (suggestion) `resend_call_count_for_test_` increment isn't atomic; document "counter bumps before any I/O" invariant in code or use `std::atomic` — `udp_bridge/src/connection.cpp:~447-449`
+- [ ] (suggestion) Test logger level restore preserves prior-test state; cheap to add a comment noting this is deliberate — `udp_bridge/test/test_remote_node_resend.cpp:668-688`
+- [ ] (suggestion) WARN known_ids list uses bare comma join; would parse ambiguously if any future id contained a comma. Quote each id — `udp_bridge/src/remote_node.cpp:~226`
+- [ ] (suggestion) `rr.connection_id.resize()` doesn't shrink_to_fit; bounded (rr is stack-local) but the field-comment "table-entry-size" argument depends on copies normalizing capacity. Add note or call shrink_to_fit — `udp_bridge/src/udp_bridge.cpp:~734`

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -336,3 +336,18 @@ Round-11 changes addressing all four valid R9 findings (which also matched the l
 
 Build clean, full suite green (85 tests, +2 vs round-10). Direct gtest filter confirmed both new tests exercise the regression paths and the ERROR log fires on the collision case.
 
+## External Review
+**Status**: complete
+**When**: 2026-05-21 15:30
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #25 — 10 review(s) (all Copilot, no human), 23 inline comments total; R10 against `b571148` generated **no new comments** ("Copilot reviewed 11 out of 11 changed files in this pull request and generated no new comments").
+**CI**: all-pass (4/4)
+
+Round-11 closes all four R9 findings (the two must-fixes + the two comment-drift suggestions). Cross-vendor signal converged: Claude fresh-context Adversarial, Governance, Copilot CLI synchronous, and Copilot R9 all flagged the same regression in round-10; the round-11 fix addressed it; Copilot's R10 confirms clean.
+
+### Actions
+- [ ] (Optional) Dismiss R1–R9 stale Copilot threads in the GitHub UI.
+- [ ] Verify PR body carries the coordinated-redeploy notice for whoever cuts the deployment (carry-over from the local /review-code Governance section).
+- [ ] Consider marking PR #25 ready for human review / out of draft.
+

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -205,3 +205,17 @@ Remaining suggestions from the local review (none must-fix; defer to follow-up i
 - Test logger level restore preserves prior-test state (low risk, by design).
 - WARN known_ids list uses bare comma join (theoretical ambiguity if ids ever contain commas).
 - `rr.connection_id.resize()` doesn't `shrink_to_fit` (bounded; stack-local).
+
+## External Review
+**Status**: complete
+**When**: 2026-05-21 03:10
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #25 — 7 review(s) (all Copilot, no human), 18 inline comments, 3 valid, 0 false positives (15 addressed by intervening commits)
+**CI**: all-pass (Prepare, Agent, Upload results, Cleanup artifacts — 4/4)
+
+### Actions
+- [ ] Fix `udp_bridge/test/test_remote_node_resend.cpp:461` — block comment says "Four tests below cover…" but the routing section now contains five tests (the bookkeeping-cap test is labeled "Routing case 5" at line 647). Update the count or factor the bookkeeping test into its own header section. (Raised twice — R6 line 476, R7 line 463.)
+- [ ] Fix `udp_bridge/include/udp_bridge/remote_node.h:220–221` — replace hard-coded `"udp_bridge.cpp around line 715"` with a function-name reference (`UDPBridge::decodeResendRequest`). Already on the local-review deferred-suggestion list above; Copilot independently flagged it.
+- [ ] Fix `udp_bridge/src/udp_bridge.cpp:801` — replace hard-coded `"udp_bridge.cpp:568-614"` with `UDPBridge::decode` by name. `decode()` is currently at 647–715 with the catch at 707–715, so the existing range is already wrong.
+- [ ] (Optional) Dismiss the stale Copilot review threads (R1–R5, and the R6 finding that R7 superseded) — concerns were resolved by intervening commits but the threads remain marked open in the GitHub UI.

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -312,8 +312,27 @@ R9 fully confirms the local /review-code findings from the prior entry. Four-way
 - `udp_bridge.cpp:1177` — stale "keyed on the full pre-truncation id from config" comment. (Matches local suggestion #1.)
 
 ### Actions
-- [ ] Fix must-fix #1 (`remote_node.cpp:35`) and must-fix #2 (`remote_node.cpp:119`) in one round-11 commit.
-- [ ] Resolve `remote_node.h:81` doc/impl drift — most consistent with the new contract: route `dispatchResendRequest` through `connection()` and update the doc comment to match.
-- [ ] Fix stale comment at `udp_bridge.cpp:1175`.
-- [ ] Add tests for `update(Remote)` long-id path + collision case.
+- [x] Fix must-fix #1 (`remote_node.cpp:35`) and must-fix #2 (`remote_node.cpp:119`) in one round-11 commit.
+- [x] Resolve `remote_node.h:81` doc/impl drift — picked the doc-update path (rather than route dispatch through `connection()`) to preserve `DispatchDoesNotFuzzyMatchConnectionId`'s intent.
+- [x] Fix stale comment at `udp_bridge.cpp:1175`.
+- [x] Add tests for `update(Remote)` long-id path + collision case.
 - [ ] (Optional) Dismiss R1–R8 stale Copilot threads in the GitHub UI.
+
+## Address External Review
+**Status**: complete
+**When**: 2026-05-21 15:20
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+Round-11 changes addressing all four valid R9 findings (which also matched the local /review-code from the prior entry — four-way convergence).
+
+- **`udp_bridge/src/remote_node.cpp`** (`update(Remote)` at line 33–48): replaced bare `connections_[c.connection_id]` with `this->connection(c.connection_id)`. The canonicalizing helper does a `find()` (no insertion on miss) so a missing entry returns null cleanly without polluting the map with an orphan untruncated-key slot. `recursive_mutex` tolerates the inner re-acquire.
+- **`udp_bridge/src/remote_node.cpp`** (`newConnection` at line 121–171): no-op when the canonical key already maps to a live Connection; returns the existing entry. If `(host, port)` differ between the new request and the existing Connection, logs an ERROR identifying both configured ids and the host/port pair on each (the actual canonical-id collision signal). Same `(host, port)` silently returns the existing — defense-in-depth for callers that miss a `connection()` lookup. `newConnection` is now idempotent for a given canonical key.
+- **`udp_bridge/include/udp_bridge/remote_node.h`** (`dispatchResendRequest` doc comment): updated to document the actual contract — caller pre-canonicalizes; the production caller (`UDPBridge::decodeResendRequest`) does so via the receive-side clamp; tests may pass either form to assert hits or misses. (Chose the doc-update over routing dispatch through `connection()` to preserve `DispatchDoesNotFuzzyMatchConnectionId`'s strict-equality intent.)
+- **`udp_bridge/src/udp_bridge.cpp`** (stale comment at the `RemoteConnectionsList` populate site): rewrote to match the post-round-10 reality (both `connection->id()` and `RemoteNode::connection()` are canonical-form).
+- **`udp_bridge/test/test_remote_node_resend.cpp`** — added two regression tests:
+  - `UpdateRemoteWithLongIdDoesNotOrphanOrClobber` (regression for must-fix #1): drives `update(Remote)` with a long configured id, asserts the canonical-keyed Connection exists, lookup via either form returns the same pointer, and a second `update(Remote)` call returns the same pointer (no clobber).
+  - `NewConnectionRejectsCanonicalIdCollision` (regression for must-fix #2): registers under "starlink" then calls with "starlink-vp" (same canonical, different host/port). Asserts the second call returns the existing pointer, host/port are preserved, and the idempotent same-input case also returns the existing pointer.
+  - Routing-section header bumped from "Six tests below…" to "Eight tests below…" with bullets for both new tests.
+
+Build clean, full suite green (85 tests, +2 vs round-10). Direct gtest filter confirmed both new tests exercise the regression paths and the ERROR log fires on the collision case.
+

--- a/.agent/work-plans/issue-23/progress.md
+++ b/.agent/work-plans/issue-23/progress.md
@@ -295,3 +295,25 @@ Build clean, full suite green (83 tests, +1 vs round-9). New test verified with 
 - [ ] (suggestion) Add tests for `update(Remote)` long-id path + collision case (two configured ids sharing first 7 chars) — `udp_bridge/test/test_remote_node_resend.cpp`
 - [ ] (suggestion) Update plan.md "Files to Change" table to include new `packet.h` helper added in round-10 — `.agent/work-plans/issue-23/plan.md`
 - [ ] (suggestion) Verify PR body carries the coordinated-redeploy notice for whoever cuts the deployment (plan flags this as open question) — PR body
+
+## External Review
+**Status**: complete
+**When**: 2026-05-21 15:00
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #25 — 9 review(s) (all Copilot, no human), 23 inline comments total; 3 new + 1 suppressed-low-confidence on R9 (against `0697ee0`)
+**CI**: all-pass (4/4)
+
+R9 fully confirms the local /review-code findings from the prior entry. Four-way convergence on the must-fixes (Claude fresh-context Adversarial, Governance, synchronous Copilot CLI, GitHub-side Copilot R9). All four findings target round-10:
+
+- `remote_node.cpp:142` — `newConnection` unconditional overwrite. (Matches local must-fix #2.)
+- `remote_node.cpp:35` (R9 suppressed-low-confidence — Copilot named the pattern but not the specific offending line). `update(Remote)` uses bare `operator[]` with untruncated id. (Matches local must-fix #1.)
+- `remote_node.h:81` — doc/impl drift on `dispatchResendRequest`. (Matches local suggestion: either update doc or route through `connection()`.)
+- `udp_bridge.cpp:1177` — stale "keyed on the full pre-truncation id from config" comment. (Matches local suggestion #1.)
+
+### Actions
+- [ ] Fix must-fix #1 (`remote_node.cpp:35`) and must-fix #2 (`remote_node.cpp:119`) in one round-11 commit.
+- [ ] Resolve `remote_node.h:81` doc/impl drift — most consistent with the new contract: route `dispatchResendRequest` through `connection()` and update the doc comment to match.
+- [ ] Fix stale comment at `udp_bridge.cpp:1175`.
+- [ ] Add tests for `update(Remote)` long-id path + collision case.
+- [ ] (Optional) Dismiss R1–R8 stale Copilot threads in the GitHub UI.

--- a/udp_bridge/CMakeLists.txt
+++ b/udp_bridge/CMakeLists.txt
@@ -94,6 +94,23 @@ if(BUILD_TESTING)
   # as-is — only the C++ preprocessor symbol is package-scoped.
   target_compile_definitions(${PROJECT_NAME} PRIVATE UDP_BRIDGE_BUILD_TESTING)
 
+  # The udp_bridge_node executable links against the library AND
+  # includes udp_bridge.h (which in turn includes connection.h
+  # directly), so its translation unit sees Connection / RemoteNode
+  # class definitions. Without the macro on this target too, the
+  # executable would compile against the smaller (production) layout
+  # while linking against a library compiled with the larger
+  # (test-augmented) layout — the same ODR hazard the test-target
+  # discipline above is designed to prevent, just for an in-package
+  # executable instead of a test target. In practice no Connection /
+  # RemoteNode is allocated by value in udp_bridge_node and no inline
+  # methods touch the conditional members, so the mismatch hasn't
+  # bitten us; but it is UB per the standard and tooling
+  # (sanitizers, ABI checkers) will flag it. Defining the macro on
+  # the executable too aligns all in-package translation units to a
+  # single layout. (Originally caught by Copilot in PR #25 review 3.)
+  target_compile_definitions(udp_bridge_node PRIVATE UDP_BRIDGE_BUILD_TESTING)
+
   find_package(ament_cmake_gtest REQUIRED)
   # std_msgs is required for the QoS-matching integration test, which
   # validates the load-bearing BEST_AVAILABLE matching guarantee

--- a/udp_bridge/CMakeLists.txt
+++ b/udp_bridge/CMakeLists.txt
@@ -65,23 +65,33 @@ install(DIRECTORY include/ DESTINATION include)
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
-  # Expose test-only helpers to the library's own compilation and to
-  # the two test targets that use them. PRIVATE on the library means
-  # the macro doesn't propagate to downstream consumers via
-  # target_link_libraries, so the UDP_BRIDGE_BUILD_TESTING-gated
-  # declarations in remote_node.h / connection.h stay hidden from the
-  # installed public ABI. Each test target that uses the helpers needs
-  # its own PRIVATE define since the library's PRIVATE flag doesn't
-  # propagate to test compilations either.
+  # Expose test-only helpers to the library's own compilation AND to
+  # every test target. PRIVATE on the library means the macro doesn't
+  # propagate to downstream consumers via target_link_libraries, so the
+  # UDP_BRIDGE_BUILD_TESTING-gated declarations in remote_node.h /
+  # connection.h stay hidden from the installed public ABI.
+  #
+  # Every test target that links against the library must define the
+  # same macro: some `UDP_BRIDGE_BUILD_TESTING`-gated entries (notably
+  # Connection::resend_call_count_for_test_, the per-connection counter
+  # introduced for issue #23 routing tests) are data members, not just
+  # methods — adding a member changes `sizeof(Connection)`. If the
+  # library is compiled with the macro and a test compilation isn't,
+  # the test sees a smaller layout, constructs Connection on the stack
+  # at the wrong size, and the library's writes scribble past it
+  # (observed as a segfault in test_connection_rate_limit before this
+  # discipline was extended package-wide). Each test target needs its
+  # own PRIVATE define since the library's PRIVATE flag doesn't
+  # propagate to test compilations.
   #
   # The macro is package-namespaced (`UDP_BRIDGE_BUILD_TESTING`, not
-  # the generic `BUILD_TESTING`) to avoid an ODR hazard: downstream
-  # packages that define `BUILD_TESTING` for their own tests and
-  # include our installed headers would otherwise see a different
-  # `RemoteNode` / `Connection` class definition than the library was
-  # built with. The CMake variable `BUILD_TESTING` (the `if(...)`
-  # check above) is the standard CMake/ament name and stays as-is —
-  # only the C++ preprocessor symbol is package-scoped.
+  # the generic `BUILD_TESTING`) to avoid the same ODR hazard for
+  # downstream packages that define `BUILD_TESTING` for their own
+  # tests and include our installed headers — they would otherwise see
+  # a different `RemoteNode` / `Connection` class definition than the
+  # library was built with. The CMake variable `BUILD_TESTING` (the
+  # `if(...)` check above) is the standard CMake/ament name and stays
+  # as-is — only the C++ preprocessor symbol is package-scoped.
   target_compile_definitions(${PROJECT_NAME} PRIVATE UDP_BRIDGE_BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
@@ -92,34 +102,26 @@ if(BUILD_TESTING)
   # CI builds from quietly losing that coverage.
   find_package(std_msgs REQUIRED)
 
-  ament_add_gtest(utest test/utest.cpp)
-  target_link_libraries(utest ${PROJECT_NAME})
+  # Helper: register a gtest, define UDP_BRIDGE_BUILD_TESTING on it,
+  # and link the library. Keeps the per-test boilerplate from
+  # forgetting the macro and reintroducing the ODR hazard documented
+  # above. Extra link libraries can be passed after the source file.
+  function(add_udp_bridge_gtest target source)
+    ament_add_gtest(${target} ${source})
+    target_compile_definitions(${target} PRIVATE UDP_BRIDGE_BUILD_TESTING)
+    target_link_libraries(${target} ${PROJECT_NAME} ${ARGN})
+  endfunction()
 
-  ament_add_gtest(test_utilities test/test_utilities.cpp)
-  target_link_libraries(test_utilities ${PROJECT_NAME})
-
-  ament_add_gtest(test_defragmenter test/test_defragmenter.cpp)
-  target_link_libraries(test_defragmenter ${PROJECT_NAME})
-
-  ament_add_gtest(test_qos_resolution test/test_qos_resolution.cpp)
-  target_link_libraries(test_qos_resolution ${PROJECT_NAME})
-
-  ament_add_gtest(test_qos_matching_integration test/test_qos_matching_integration.cpp)
-  target_link_libraries(test_qos_matching_integration
-    ${PROJECT_NAME}
-    ${std_msgs_TARGETS}
-  )
-
-  ament_add_gtest(test_connection_rate_limit test/test_connection_rate_limit.cpp)
-  target_link_libraries(test_connection_rate_limit ${PROJECT_NAME})
-
-  ament_add_gtest(test_remote_node_resend test/test_remote_node_resend.cpp)
-  target_compile_definitions(test_remote_node_resend PRIVATE UDP_BRIDGE_BUILD_TESTING)
-  target_link_libraries(test_remote_node_resend ${PROJECT_NAME})
-
-  ament_add_gtest(test_connection_cleanup test/test_connection_cleanup.cpp)
-  target_compile_definitions(test_connection_cleanup PRIVATE UDP_BRIDGE_BUILD_TESTING)
-  target_link_libraries(test_connection_cleanup ${PROJECT_NAME})
+  add_udp_bridge_gtest(utest test/utest.cpp)
+  add_udp_bridge_gtest(test_utilities test/test_utilities.cpp)
+  add_udp_bridge_gtest(test_defragmenter test/test_defragmenter.cpp)
+  add_udp_bridge_gtest(test_qos_resolution test/test_qos_resolution.cpp)
+  add_udp_bridge_gtest(test_qos_matching_integration
+    test/test_qos_matching_integration.cpp
+    ${std_msgs_TARGETS})
+  add_udp_bridge_gtest(test_connection_rate_limit test/test_connection_rate_limit.cpp)
+  add_udp_bridge_gtest(test_remote_node_resend test/test_remote_node_resend.cpp)
+  add_udp_bridge_gtest(test_connection_cleanup test/test_connection_cleanup.cpp)
 endif()
 
 ament_package()

--- a/udp_bridge/include/udp_bridge/connection.h
+++ b/udp_bridge/include/udp_bridge/connection.h
@@ -124,6 +124,16 @@ public:
   /// what evicted vs what stayed. Not for production callers.
   /// UDP_BRIDGE_BUILD_TESTING-gated for the same reason as the helper above.
   std::size_t sent_packet_count_for_test() const;
+
+  /// Test accessor: returns how many times resend_packets has been
+  /// invoked on this Connection since construction. Used by the
+  /// dispatch-routing tests in test_remote_node_resend.cpp to assert
+  /// that a stamped ResendRequest reaches only the matching connection
+  /// (issue #23). Incremented at entry of resend_packets (before any
+  /// network I/O), so an empty missing-packet list still counts as a
+  /// call. UDP_BRIDGE_BUILD_TESTING-gated for the same reason as the
+  /// helpers above.
+  std::size_t resend_call_count_for_test() const;
 #endif  // UDP_BRIDGE_BUILD_TESTING
 
 private:
@@ -192,6 +202,17 @@ private:
   /// (reads), and cleanup_sent_packets (writes), which can be invoked
   /// from different callback groups under MultiThreadedExecutor.
   mutable std::mutex sent_packets_mutex_;
+
+#ifdef UDP_BRIDGE_BUILD_TESTING
+  /// Test-only counter: number of times resend_packets() has been
+  /// invoked. Bumped at the top of resend_packets, before any I/O,
+  /// under sent_packets_mutex_ so the increment piggybacks on the
+  /// lock that resend_packets already takes (no separate atomic).
+  /// Read via resend_call_count_for_test() under the same mutex.
+  /// Gated behind UDP_BRIDGE_BUILD_TESTING so it doesn't change the
+  /// production object layout.
+  std::size_t resend_call_count_for_test_ = 0;
+#endif  // UDP_BRIDGE_BUILD_TESTING
 
   PacketSendStatistics sent_packet_statistics_;
   /// Guards sent_packet_statistics_ and reserved_bytes_in_flight_.

--- a/udp_bridge/include/udp_bridge/packet.h
+++ b/udp_bridge/include/udp_bridge/packet.h
@@ -19,6 +19,27 @@ namespace udp_bridge
 constexpr uint8_t maximum_node_name_size = 24;
 constexpr uint8_t maximum_connection_id_size = 8;
 
+// Canonical wire form of a connection id: the leading
+// `maximum_connection_id_size - 1` bytes of the input (the trailing
+// byte of the on-wire char array is the null terminator).
+//
+// Centralizing the truncation here keeps the receive-side wire clamp
+// (UDPBridge::decodeResendRequest), the sender-side stamp
+// (UDPBridge::resendMissingPackets), and the connection-map insertion
+// points (RemoteNode::newConnection / connection,
+// Connection::Connection) using the same canonical form. The
+// connections_ map is keyed on this canonical form so that a
+// ResendRequest stamped with the truncated wire id always finds the
+// connection that holds sent_packets_ for that link, even when the
+// configured id is longer than the on-wire field — closes the
+// truncation-contract gap that bit issue #23's round-8 self-review.
+inline std::string truncate_connection_id(const std::string& id)
+{
+  if(id.size() < maximum_connection_id_size)
+    return id;
+  return id.substr(0, maximum_connection_id_size - 1);
+}
+
 /// Packet type identifiers.
 /// \ingroup packet
 enum class PacketType: uint8_t {

--- a/udp_bridge/include/udp_bridge/remote_node.h
+++ b/udp_bridge/include/udp_bridge/remote_node.h
@@ -63,13 +63,20 @@ class RemoteNode
   // Route a ResendRequest to the single connection it was stamped for
   // (issue #23). Looks up connection(rr.connection_id) and forwards to
   // its resend_packets. If the id is not in connections_, no-op and
-  // emit a DEBUG log naming both the stamped id and the set of
-  // currently known connection ids — this branch fires both on
-  // legitimate sender/receiver races (the receiver tore the connection
-  // down for a CONNECT cycle or config reload between the sender
-  // stamping the request and us decoding it) and on bona-fide
-  // coordinated-redeploy mismatches, so the log line needs enough
-  // context for an operator to distinguish them.
+  // emit a log naming both the stamped id and the set of currently
+  // known connection ids: WARN on the first miss per stamped id
+  // (a genuine coordinated-redeploy mismatch needs to be diagnosable
+  // at default log levels), DEBUG on subsequent misses for the same id
+  // (legitimate CONNECT-cycle races shouldn't spam). The known-ids
+  // payload gives an operator enough context to distinguish the two
+  // operational scenarios that share this path:
+  //   - Legitimate race: the receiver tore the connection down for a
+  //     CONNECT cycle or config reload between the sender stamping
+  //     the request and us decoding it; resolves on the next BridgeInfo.
+  //   - Coordinated-redeploy mismatch: the two bridges' connection-id
+  //     strings don't agree; does not self-resolve.
+  // First-miss bookkeeping lives in dispatch_miss_warned_ids_ (see
+  // field comment below).
   //
   // Caller MUST NOT hold state_mutex_. The method takes it briefly for
   // the lookup, then releases it before invoking

--- a/udp_bridge/include/udp_bridge/remote_node.h
+++ b/udp_bridge/include/udp_bridge/remote_node.h
@@ -60,6 +60,24 @@ class RemoteNode
 
   std::vector<std::vector<uint8_t> > getPacketsToResend(const udp_bridge_interfaces::msg::ResendRequest& resend_request);
 
+  // Route a ResendRequest to the single connection it was stamped for
+  // (issue #23). Looks up connection(rr.connection_id) and forwards to
+  // its resend_packets. If the id is not in connections_, no-op and
+  // emit a DEBUG log naming both the stamped id and the set of
+  // currently known connection ids — this branch fires both on
+  // legitimate sender/receiver races (the receiver tore the connection
+  // down for a CONNECT cycle or config reload between the sender
+  // stamping the request and us decoding it) and on bona-fide
+  // coordinated-redeploy mismatches, so the log line needs enough
+  // context for an operator to distinguish them.
+  //
+  // Caller MUST NOT hold state_mutex_. The method takes it briefly for
+  // the lookup, then releases it before invoking
+  // Connection::resend_packets (which does socket I/O) — mirrors the
+  // snapshot-then-iterate locking discipline elsewhere in this class.
+  void dispatchResendRequest(const udp_bridge_interfaces::msg::ResendRequest& rr,
+                             int socket, rclcpp::Time now);
+
   Defragmenter& defragmenter();
 
   void publishTopicStatistics(const udp_bridge_interfaces::msg::TopicStatisticsArray& statistics);

--- a/udp_bridge/include/udp_bridge/remote_node.h
+++ b/udp_bridge/include/udp_bridge/remote_node.h
@@ -174,6 +174,15 @@ private:
 
   std::map<std::string, std::shared_ptr<Connection> > connections_;
 
+  // Ids we've already emitted a WARN for in dispatchResendRequest's
+  // lookup-miss path. The first miss for an id surfaces as WARN (a
+  // genuine coordinated-redeploy mismatch needs to be diagnosable);
+  // subsequent misses for the same id drop to DEBUG to avoid spamming
+  // during legitimate CONNECT-cycle races. Guarded by state_mutex_;
+  // never pruned — the set is bounded by the configuration space of
+  // legitimate-then-removed connection ids, which is small.
+  std::set<std::string> dispatch_miss_warned_ids_;
+
   Defragmenter defragmenter_;
 
   std::map<uint64_t, rclcpp::Time> received_packet_times_;

--- a/udp_bridge/include/udp_bridge/remote_node.h
+++ b/udp_bridge/include/udp_bridge/remote_node.h
@@ -130,6 +130,23 @@ class RemoteNode
   // UDP_BRIDGE_BUILD_TESTING-gated for the same reason as the helpers
   // above.
   std::size_t dispatchMissWarnedIdCountForTest() const;
+
+  // Test accessor: returns true iff `id` is currently in the
+  // dispatch-miss WARN bookkeeping (i.e., the next miss for this id
+  // would log at DEBUG, not WARN). Used by the FIFO-order assertion
+  // in the cap-enforcement test to verify that the eviction policy
+  // is in-order (oldest dropped first, not random/newest). Takes
+  // state_mutex_ for the read.
+  // UDP_BRIDGE_BUILD_TESTING-gated.
+  bool isDispatchMissWarnedForTest(const std::string& id) const;
+
+  // Test accessor: returns the dispatch-miss WARN bookkeeping cap.
+  // Lets the cap-enforcement test assert against the exact cap value
+  // (catching a "doubled cap" regression) without making
+  // kDispatchMissWarnedCap part of the public API.
+  // UDP_BRIDGE_BUILD_TESTING-gated.
+  static constexpr std::size_t dispatchMissWarnedCapForTest()
+  { return kDispatchMissWarnedCap; }
 #endif  // UDP_BRIDGE_BUILD_TESTING
 
   // Count of missing-packet resends this RemoteNode has given up on

--- a/udp_bridge/include/udp_bridge/remote_node.h
+++ b/udp_bridge/include/udp_bridge/remote_node.h
@@ -217,9 +217,9 @@ private:
   //
   // Bounded FIFO with O(1) lookup. The ids come from network-supplied
   // ResendRequest.connection_id strings (clamped to 7 bytes at the
-  // receive side in UDPBridge::decodeResendRequest, see udp_bridge.cpp
-  // around line 715), so per-entry size is bounded but the *count* of
-  // distinct ids isn't bounded by anything in the wire protocol. A
+  // receive side in UDPBridge::decodeResendRequest), so per-entry size
+  // is bounded but the *count* of distinct ids isn't bounded by
+  // anything in the wire protocol. A
   // misbehaving peer or a stream of bit-flipped-but-deserializable
   // packets could otherwise grow the set unboundedly. We cap the
   // bookkeeping at kDispatchMissWarnedCap (256) entries:

--- a/udp_bridge/include/udp_bridge/remote_node.h
+++ b/udp_bridge/include/udp_bridge/remote_node.h
@@ -216,10 +216,14 @@ private:
   // during legitimate CONNECT-cycle races.
   //
   // Bounded FIFO with O(1) lookup. The ids come from network-supplied
-  // ResendRequest.connection_id strings (clamped to 7 bytes at the
-  // receive side in UDPBridge::decodeResendRequest), so per-entry size
-  // is bounded but the *count* of distinct ids isn't bounded by
-  // anything in the wire protocol. A
+  // ResendRequest.connection_id strings. Well-behaved peers send them
+  // pre-canonicalized to the wire form (PR #25 runs every connections_
+  // insertion through truncate_connection_id, so connection->id() is
+  // ≤ maximum_connection_id_size - 1 and the sender stamps that), and
+  // a defensive clamp in UDPBridge::decodeResendRequest enforces the
+  // same shape on misbehaving peers. Per-entry size is therefore
+  // bounded by 7 bytes, but the *count* of distinct ids a peer can
+  // stamp isn't bounded by anything in the wire protocol. A
   // misbehaving peer or a stream of bit-flipped-but-deserializable
   // packets could otherwise grow the set unboundedly. We cap the
   // bookkeeping at kDispatchMissWarnedCap (256) entries:

--- a/udp_bridge/include/udp_bridge/remote_node.h
+++ b/udp_bridge/include/udp_bridge/remote_node.h
@@ -11,6 +11,7 @@
 
 #include <deque>
 #include <mutex>
+#include <set>
 #include <unordered_set>
 
 #include "rclcpp/rclcpp.hpp"

--- a/udp_bridge/include/udp_bridge/remote_node.h
+++ b/udp_bridge/include/udp_bridge/remote_node.h
@@ -63,10 +63,18 @@ class RemoteNode
   std::vector<std::vector<uint8_t> > getPacketsToResend(const udp_bridge_interfaces::msg::ResendRequest& resend_request);
 
   // Route a ResendRequest to the single connection it was stamped for
-  // (issue #23). Looks up connection(rr.connection_id) and forwards to
-  // its resend_packets. If the id is not in connections_, no-op and
-  // emit a log naming both the stamped id and the set of currently
-  // known connection ids: WARN on the first miss per stamped id
+  // (issue #23). Does a strict-equality lookup on `rr.connection_id`
+  // in `connections_` and forwards to the matching connection's
+  // `resend_packets`. The caller is responsible for ensuring
+  // `rr.connection_id` is already in the canonical wire form —
+  // production callers go through `UDPBridge::decodeResendRequest`,
+  // whose receive-side clamp normalizes the incoming string before
+  // dispatch. (Unit tests that exercise dispatch directly may pass
+  // either a canonical id, or a non-canonical id to assert a miss; see
+  // `DispatchDoesNotFuzzyMatchConnectionId`.) If the id is not in
+  // connections_, no-op and emit a log naming both the stamped id and
+  // the set of currently known connection ids: WARN on the first miss
+  // per stamped id
   // (a genuine coordinated-redeploy mismatch needs to be diagnosable
   // at default log levels), DEBUG on subsequent misses for the same id
   // (legitimate CONNECT-cycle races shouldn't spam). The known-ids

--- a/udp_bridge/include/udp_bridge/remote_node.h
+++ b/udp_bridge/include/udp_bridge/remote_node.h
@@ -9,8 +9,9 @@
 #include "udp_bridge_interfaces/msg/bridge_info.hpp"
 #include "udp_bridge/types.h"
 
+#include <deque>
 #include <mutex>
-#include <set>
+#include <unordered_set>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/node_interfaces/node_interfaces.hpp"
@@ -119,6 +120,15 @@ class RemoteNode
   // give-up scenarios. UDP_BRIDGE_BUILD_TESTING-gated for the same reason as the
   // overload above.
   void recordReceivedPacketTimeForTest(uint64_t packet_number, rclcpp::Time time);
+
+  // Test accessor: returns the current count of ids in the
+  // dispatch-miss WARN bookkeeping. Used by the cap-enforcement test
+  // to verify that pumping > kDispatchMissWarnedCap distinct ids
+  // through dispatchResendRequest doesn't grow the table without
+  // bound. Takes state_mutex_ for the read.
+  // UDP_BRIDGE_BUILD_TESTING-gated for the same reason as the helpers
+  // above.
+  std::size_t dispatchMissWarnedIdCountForTest() const;
 #endif  // UDP_BRIDGE_BUILD_TESTING
 
   // Count of missing-packet resends this RemoteNode has given up on
@@ -185,10 +195,29 @@ private:
   // lookup-miss path. The first miss for an id surfaces as WARN (a
   // genuine coordinated-redeploy mismatch needs to be diagnosable);
   // subsequent misses for the same id drop to DEBUG to avoid spamming
-  // during legitimate CONNECT-cycle races. Guarded by state_mutex_;
-  // never pruned — the set is bounded by the configuration space of
-  // legitimate-then-removed connection ids, which is small.
-  std::set<std::string> dispatch_miss_warned_ids_;
+  // during legitimate CONNECT-cycle races.
+  //
+  // Bounded FIFO with O(1) lookup. The ids come from network-supplied
+  // ResendRequest.connection_id strings (clamped to 7 bytes at the
+  // receive side in UDPBridge::decodeResendRequest, see udp_bridge.cpp
+  // around line 715), so per-entry size is bounded but the *count* of
+  // distinct ids isn't bounded by anything in the wire protocol. A
+  // misbehaving peer or a stream of bit-flipped-but-deserializable
+  // packets could otherwise grow the set unboundedly. We cap the
+  // bookkeeping at kDispatchMissWarnedCap (256) entries:
+  // dispatch_miss_warned_order_ holds insertion order (FIFO), and the
+  // unordered_set holds the same ids for O(1) presence checks. When
+  // the cap is hit, we evict the oldest id from both — that id
+  // becomes WARN-eligible again the next time it's seen, which is the
+  // right behavior for a rate-limit-the-WARN bookkeeping table (vs
+  // permanently silencing it). The cap is comfortably above any
+  // plausible configured id space (typical deployments have 2–4
+  // connections, never more than a few dozen).
+  //
+  // Both containers are guarded by state_mutex_.
+  static constexpr std::size_t kDispatchMissWarnedCap = 256;
+  std::deque<std::string> dispatch_miss_warned_order_;
+  std::unordered_set<std::string> dispatch_miss_warned_ids_;
 
   Defragmenter defragmenter_;
 

--- a/udp_bridge/src/connection.cpp
+++ b/udp_bridge/src/connection.cpp
@@ -14,8 +14,11 @@ namespace udp_bridge
 using namespace udp_bridge_interfaces::msg;
 
 Connection::Connection(std::string id, std::string const &host, uint16_t port, std::string return_host, uint16_t return_port):
-  id_(id), host_(host), port_(port), return_host_(return_host), return_port_(return_port)
+  id_(truncate_connection_id(id)), host_(host), port_(port), return_host_(return_host), return_port_(return_port)
 {
+  // id_ is canonicalized so connection->id() always returns the
+  // on-wire form. Higher-level entry points (RemoteNode::newConnection)
+  // surface a one-time WARN when this truncation actually shortens.
   std::lock_guard<std::recursive_mutex> lock(config_mutex_);
   resolveHost();  // re-enters mutex (recursive)
 }

--- a/udp_bridge/src/connection.cpp
+++ b/udp_bridge/src/connection.cpp
@@ -444,6 +444,9 @@ void Connection::resend_packets(const std::vector<uint64_t> &missing_packets, in
   std::vector<std::vector<uint8_t>> packets_to_resend;
   {
     std::lock_guard<std::mutex> lock(sent_packets_mutex_);
+#ifdef UDP_BRIDGE_BUILD_TESTING
+    ++resend_call_count_for_test_;
+#endif
     packets_to_resend.reserve(missing_packets.size());
     for(auto packet_number: missing_packets)
     {
@@ -486,6 +489,12 @@ std::size_t Connection::sent_packet_count_for_test() const
 {
   std::lock_guard<std::mutex> lock(sent_packets_mutex_);
   return sent_packets_.size();
+}
+
+std::size_t Connection::resend_call_count_for_test() const
+{
+  std::lock_guard<std::mutex> lock(sent_packets_mutex_);
+  return resend_call_count_for_test_;
 }
 #endif  // UDP_BRIDGE_BUILD_TESTING
 

--- a/udp_bridge/src/remote_node.cpp
+++ b/udp_bridge/src/remote_node.cpp
@@ -97,6 +97,11 @@ std::string RemoteNode::topicName() const
 
 std::shared_ptr<Connection> RemoteNode::connection(std::string connection_id)
 {
+  // Canonicalize lookup key so callers can pass either the configured
+  // (untruncated) id or the on-wire (truncated) form and get the same
+  // connection. connections_ is keyed on the canonical (truncated)
+  // form by construction (see newConnection / adoptConnection).
+  connection_id = truncate_connection_id(connection_id);
   std::lock_guard<std::recursive_mutex> lock(state_mutex_);
   if(connections_.find(connection_id) != connections_.end())
     return connections_[connection_id];
@@ -115,9 +120,26 @@ std::vector<std::shared_ptr<Connection> > RemoteNode::connections()
 
 std::shared_ptr<Connection> RemoteNode::newConnection(std::string connection_id, std::string host, uint16_t port)
 {
+  // Canonicalize to the on-wire form so connections_ keys, Connection::id(),
+  // and rr.connection_id (which carries the wire-truncated form on the
+  // resend path) all agree. Surface a WARN when the input actually
+  // shortens so operators learn at startup that an ≥8-char configured
+  // id is being normalized — and that two configured ids with the same
+  // first 7 chars would collide under the canonical form.
+  const std::string canonical_id = truncate_connection_id(connection_id);
+  if(canonical_id != connection_id)
+  {
+    RCLCPP_WARN_STREAM(logger_,
+      "Connection id '" << connection_id << "' truncated to '"
+      << canonical_id << "' for the on-wire form (limit "
+      << (maximum_connection_id_size - 1) << " chars). Rename the "
+         "configured id to avoid the truncation; two configured ids "
+         "sharing the first " << (maximum_connection_id_size - 1)
+      << " characters will collide under this canonical form.");
+  }
   std::lock_guard<std::recursive_mutex> lock(state_mutex_);
-  connections_[connection_id] = std::make_shared<Connection>(connection_id, host, port);
-  return connections_[connection_id];
+  connections_[canonical_id] = std::make_shared<Connection>(canonical_id, host, port);
+  return connections_[canonical_id];
 }
 
 void RemoteNode::adoptConnection(std::shared_ptr<Connection> connection)

--- a/udp_bridge/src/remote_node.cpp
+++ b/udp_bridge/src/remote_node.cpp
@@ -223,7 +223,9 @@ void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclc
       "Dropping ResendRequest from " << name_
       << " stamped for connection_id='" << rr.connection_id
       << "' (no matching connection; known ids: [" << joined << "]). "
-         "Further misses for this id will log at DEBUG.");
+         "Further misses for this id will log at DEBUG (until the "
+         "rate-limit table evicts this id under pressure, at which "
+         "point the WARN re-fires on next sighting).");
   }
   else
   {
@@ -365,6 +367,12 @@ std::size_t RemoteNode::dispatchMissWarnedIdCountForTest() const
 {
   std::lock_guard<std::recursive_mutex> lock(state_mutex_);
   return dispatch_miss_warned_ids_.size();
+}
+
+bool RemoteNode::isDispatchMissWarnedForTest(const std::string& id) const
+{
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+  return dispatch_miss_warned_ids_.count(id) != 0;
 }
 #endif  // UDP_BRIDGE_BUILD_TESTING
 

--- a/udp_bridge/src/remote_node.cpp
+++ b/udp_bridge/src/remote_node.cpp
@@ -148,9 +148,6 @@ void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclc
       target = it->second;
     if(!target)
     {
-      known_ids.reserve(connections_.size());
-      for(const auto& kv : connections_)
-        known_ids.push_back(kv.first);
       // First-miss-per-id bookkeeping with a bounded FIFO. We pick
       // WARN vs DEBUG below by whether this id has already been
       // warned for: first occurrence surfaces (so a real config
@@ -179,6 +176,16 @@ void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclc
         dispatch_miss_warned_ids_.insert(rr.connection_id);
         first_miss_for_id = true;
       }
+      // Snapshot known ids only when we'll WARN below — the DEBUG
+      // branch omits the list (already shown on the prior WARN line)
+      // so building it here would be wasted work on the common
+      // repeated-miss / cap-saturated paths.
+      if(first_miss_for_id)
+      {
+        known_ids.reserve(connections_.size());
+        for(const auto& kv : connections_)
+          known_ids.push_back(kv.first);
+      }
     }
   }
   if(target)
@@ -197,15 +204,21 @@ void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclc
   // Both deserve diagnostic output. The known-ids list and the
   // first-vs-subsequent split together let an operator distinguish:
   // a one-shot WARN that never repeats is a transient race; repeated
-  // hits on the same id (now DEBUG) suggest the race is ongoing.
-  std::string joined;
-  for(size_t i = 0; i < known_ids.size(); ++i)
-  {
-    if(i > 0) joined += ", ";
-    joined += known_ids[i];
-  }
+  // hits on the same id (now DEBUG) suggest the race is ongoing. The
+  // DEBUG path omits the known-ids list — the WARN that fired on the
+  // first miss already showed it, and avoiding the per-DEBUG join
+  // keeps the lookup-miss path cheap even when the table is
+  // saturated (cap-eviction scenarios re-WARN with a fresh known_ids
+  // list, so an operator chasing a repeating issue always has the
+  // current ids on the most recent WARN line).
   if(first_miss_for_id)
   {
+    std::string joined;
+    for(size_t i = 0; i < known_ids.size(); ++i)
+    {
+      if(i > 0) joined += ", ";
+      joined += known_ids[i];
+    }
     RCLCPP_WARN_STREAM(logger_,
       "Dropping ResendRequest from " << name_
       << " stamped for connection_id='" << rr.connection_id
@@ -217,7 +230,8 @@ void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclc
     RCLCPP_DEBUG_STREAM(logger_,
       "Dropping ResendRequest from " << name_
       << " stamped for connection_id='" << rr.connection_id
-      << "' (no matching connection; known ids: [" << joined << "])");
+      << "' (no matching connection; see the prior WARN line for "
+         "this id for the known-ids snapshot)");
   }
 }
 

--- a/udp_bridge/src/remote_node.cpp
+++ b/udp_bridge/src/remote_node.cpp
@@ -151,13 +151,34 @@ void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclc
       known_ids.reserve(connections_.size());
       for(const auto& kv : connections_)
         known_ids.push_back(kv.first);
-      // First-miss-per-id bookkeeping: insert returns {iterator, true}
-      // when the id was newly added. We use that to pick WARN vs DEBUG
-      // below — first occurrence per id surfaces (so a real config
+      // First-miss-per-id bookkeeping with a bounded FIFO. We pick
+      // WARN vs DEBUG below by whether this id has already been
+      // warned for: first occurrence surfaces (so a real config
       // mismatch is diagnosable at default log levels); subsequent
       // occurrences drop to DEBUG so legitimate CONNECT-cycle races
-      // don't spam.
-      first_miss_for_id = dispatch_miss_warned_ids_.insert(rr.connection_id).second;
+      // don't spam. When the bookkeeping table is full, we evict the
+      // oldest entry FIFO-style — that id becomes WARN-eligible
+      // again if seen later, which is the right behavior for a
+      // rate-limit table (vs permanently silencing a stale id). See
+      // the field comment on dispatch_miss_warned_ids_ in
+      // remote_node.h for the threat-model rationale (network-
+      // supplied strings shouldn't be able to grow this table
+      // without bound, even with the 7-byte size clamp).
+      if(dispatch_miss_warned_ids_.count(rr.connection_id) != 0)
+      {
+        first_miss_for_id = false;
+      }
+      else
+      {
+        if(dispatch_miss_warned_order_.size() >= kDispatchMissWarnedCap)
+        {
+          dispatch_miss_warned_ids_.erase(dispatch_miss_warned_order_.front());
+          dispatch_miss_warned_order_.pop_front();
+        }
+        dispatch_miss_warned_order_.push_back(rr.connection_id);
+        dispatch_miss_warned_ids_.insert(rr.connection_id);
+        first_miss_for_id = true;
+      }
     }
   }
   if(target)
@@ -324,6 +345,12 @@ void RemoteNode::recordReceivedPacketTimeForTest(uint64_t packet_number, rclcpp:
 {
   std::lock_guard<std::recursive_mutex> lock(state_mutex_);
   recordPacketArrival(packet_number, time);
+}
+
+std::size_t RemoteNode::dispatchMissWarnedIdCountForTest() const
+{
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+  return dispatch_miss_warned_ids_.size();
 }
 #endif  // UDP_BRIDGE_BUILD_TESTING
 

--- a/udp_bridge/src/remote_node.cpp
+++ b/udp_bridge/src/remote_node.cpp
@@ -132,12 +132,15 @@ void RemoteNode::adoptConnection(std::shared_ptr<Connection> connection)
 
 void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclcpp::Time now)
 {
-  // Snapshot the target connection (or, on miss, the set of known ids)
-  // under state_mutex_, then release the mutex before calling
-  // resend_packets — Connection::resend_packets does socket I/O and
-  // must not run under our state lock.
+  // Snapshot the target connection (or, on miss, the set of known ids
+  // and a flag for whether this is the first miss for this id) under
+  // state_mutex_, then release the mutex before calling resend_packets
+  // / emitting the log — Connection::resend_packets does socket I/O
+  // and rclcpp logging macros do their own internal locking that we
+  // don't want nested under state_mutex_.
   std::shared_ptr<Connection> target;
   std::vector<std::string> known_ids;
+  bool first_miss_for_id = false;
   {
     std::lock_guard<std::recursive_mutex> lock(state_mutex_);
     auto it = connections_.find(rr.connection_id);
@@ -148,6 +151,13 @@ void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclc
       known_ids.reserve(connections_.size());
       for(const auto& kv : connections_)
         known_ids.push_back(kv.first);
+      // First-miss-per-id bookkeeping: insert returns {iterator, true}
+      // when the id was newly added. We use that to pick WARN vs DEBUG
+      // below — first occurrence per id surfaces (so a real config
+      // mismatch is diagnosable at default log levels); subsequent
+      // occurrences drop to DEBUG so legitimate CONNECT-cycle races
+      // don't spam.
+      first_miss_for_id = dispatch_miss_warned_ids_.insert(rr.connection_id).second;
     }
   }
   if(target)
@@ -155,22 +165,39 @@ void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclc
     target->resend_packets(rr.missing_packets, socket, now);
     return;
   }
-  // Fires on legitimate sender/receiver races (the receiver tore the
-  // connection down for a CONNECT cycle or config reload between the
-  // sender stamping the request and us decoding it) AND on bona-fide
-  // coordinated-redeploy mismatches. Log both the stamped id and the
-  // set of currently known connection ids so an operator chasing
-  // either case has enough to diagnose.
+  // Lookup miss. Two operational scenarios share this path:
+  //   - Legitimate race: receiver tore the connection down for a
+  //     CONNECT cycle or config reload between the sender stamping the
+  //     request and us decoding it. Resolves on the next BridgeInfo.
+  //   - Coordinated-redeploy mismatch: the two bridges' connection-id
+  //     strings don't agree (or, with this PR's truncation, an id
+  //     ≥ maximum_connection_id_size that was somehow stamped
+  //     untruncated reaches the receiver). Does not self-resolve.
+  // Both deserve diagnostic output. The known-ids list and the
+  // first-vs-subsequent split together let an operator distinguish:
+  // a one-shot WARN that never repeats is a transient race; repeated
+  // hits on the same id (now DEBUG) suggest the race is ongoing.
   std::string joined;
   for(size_t i = 0; i < known_ids.size(); ++i)
   {
     if(i > 0) joined += ", ";
     joined += known_ids[i];
   }
-  RCLCPP_DEBUG_STREAM(logger_,
-    "Dropping ResendRequest from " << name_
-    << " stamped for connection_id='" << rr.connection_id
-    << "' (no matching connection; known ids: [" << joined << "])");
+  if(first_miss_for_id)
+  {
+    RCLCPP_WARN_STREAM(logger_,
+      "Dropping ResendRequest from " << name_
+      << " stamped for connection_id='" << rr.connection_id
+      << "' (no matching connection; known ids: [" << joined << "]). "
+         "Further misses for this id will log at DEBUG.");
+  }
+  else
+  {
+    RCLCPP_DEBUG_STREAM(logger_,
+      "Dropping ResendRequest from " << name_
+      << " stamped for connection_id='" << rr.connection_id
+      << "' (no matching connection; known ids: [" << joined << "])");
+  }
 }
 
 

--- a/udp_bridge/src/remote_node.cpp
+++ b/udp_bridge/src/remote_node.cpp
@@ -32,7 +32,17 @@ void RemoteNode::update(const Remote& remote_message)
   std::lock_guard<std::recursive_mutex> lock(state_mutex_);
   for(auto c: remote_message.connections)
   {
-    auto connection = connections_[c.connection_id];
+    // Use the canonicalizing helper rather than a raw `connections_[]`
+    // index — bare `operator[]` with the untruncated configured id
+    // would default-construct a null shared_ptr at the *uncanonical*
+    // key for any id ≥ maximum_connection_id_size. That left an orphan
+    // slot alongside the real canonical-keyed entry from
+    // newConnection(), and on the next refresh through this loop the
+    // (still-null) orphan re-entered the `if(!connection)` branch and
+    // newConnection's overwrite path wiped the live Connection's
+    // sent_packets_ / stats. Caught by R9 review on PR #25 and three
+    // independent local reviewers (Adversarial, Governance, Copilot CLI).
+    auto connection = this->connection(c.connection_id);
     if(!connection)
       connection = newConnection(c.connection_id, c.host, c.port);
     connection->setReturnHostAndPort(c.return_host, c.return_port);
@@ -138,8 +148,41 @@ std::shared_ptr<Connection> RemoteNode::newConnection(std::string connection_id,
       << " characters will collide under this canonical form.");
   }
   std::lock_guard<std::recursive_mutex> lock(state_mutex_);
-  connections_[canonical_id] = std::make_shared<Connection>(canonical_id, host, port);
-  return connections_[canonical_id];
+  auto& slot = connections_[canonical_id];
+  if(slot)
+  {
+    // A Connection already exists at this canonical key. Two cases:
+    //   1) Same (host, port): caller missed a connection() lookup and
+    //      reached us defensively. Return the existing entry — clobbering
+    //      it would wipe sent_packets_ / received-rate state for no
+    //      benefit. The other call sites already do the
+    //      `if(!c) c = newConnection(...)` dance; the no-op here makes
+    //      the rule "newConnection is idempotent for a given canonical
+    //      key" hold for any future caller too.
+    //   2) Different (host, port): canonical-id collision — two distinct
+    //      configured ids share the first `maximum_connection_id_size - 1`
+    //      chars (e.g. "starlink-ku" / "starlink-vp" both canonicalize
+    //      to "starlin"). The first-registered Connection is kept; the
+    //      second is rejected. Log an ERROR so a misconfigured
+    //      deployment surfaces at startup rather than presenting as
+    //      silent state-clobber on the next RemoteNode::update(Remote)
+    //      refresh.
+    if(slot->host() != host || slot->port() != port)
+    {
+      RCLCPP_ERROR_STREAM(logger_,
+        "Connection id collision: '" << connection_id
+        << "' canonicalizes to '" << canonical_id
+        << "' but a Connection already exists at that key with "
+           "host=" << slot->host() << " port=" << slot->port()
+        << "; new request was host=" << host << " port=" << port
+        << ". The first-registered connection is kept. Rename one of "
+           "the configured ids so they don't share the first "
+        << (maximum_connection_id_size - 1) << " characters.");
+    }
+    return slot;
+  }
+  slot = std::make_shared<Connection>(canonical_id, host, port);
+  return slot;
 }
 
 void RemoteNode::adoptConnection(std::shared_ptr<Connection> connection)

--- a/udp_bridge/src/remote_node.cpp
+++ b/udp_bridge/src/remote_node.cpp
@@ -130,6 +130,49 @@ void RemoteNode::adoptConnection(std::shared_ptr<Connection> connection)
     slot = connection;
 }
 
+void RemoteNode::dispatchResendRequest(const ResendRequest& rr, int socket, rclcpp::Time now)
+{
+  // Snapshot the target connection (or, on miss, the set of known ids)
+  // under state_mutex_, then release the mutex before calling
+  // resend_packets — Connection::resend_packets does socket I/O and
+  // must not run under our state lock.
+  std::shared_ptr<Connection> target;
+  std::vector<std::string> known_ids;
+  {
+    std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+    auto it = connections_.find(rr.connection_id);
+    if(it != connections_.end())
+      target = it->second;
+    if(!target)
+    {
+      known_ids.reserve(connections_.size());
+      for(const auto& kv : connections_)
+        known_ids.push_back(kv.first);
+    }
+  }
+  if(target)
+  {
+    target->resend_packets(rr.missing_packets, socket, now);
+    return;
+  }
+  // Fires on legitimate sender/receiver races (the receiver tore the
+  // connection down for a CONNECT cycle or config reload between the
+  // sender stamping the request and us decoding it) AND on bona-fide
+  // coordinated-redeploy mismatches. Log both the stamped id and the
+  // set of currently known connection ids so an operator chasing
+  // either case has enough to diagnose.
+  std::string joined;
+  for(size_t i = 0; i < known_ids.size(); ++i)
+  {
+    if(i > 0) joined += ", ";
+    joined += known_ids[i];
+  }
+  RCLCPP_DEBUG_STREAM(logger_,
+    "Dropping ResendRequest from " << name_
+    << " stamped for connection_id='" << rr.connection_id
+    << "' (no matching connection; known ids: [" << joined << "])");
+}
+
 
 std::vector<uint8_t> RemoteNode::unwrap(std::vector<uint8_t> const &message, const SourceInfo& source_info)
 {

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -694,12 +694,23 @@ void UDPBridge::decodeBridgeInfo(std::vector<uint8_t> const &message, const Sour
 
 void UDPBridge::decodeResendRequest(std::vector<uint8_t> const &message, const SourceInfo& source_info)
 {
-  // Catch deserialization failure here so a mismatched/corrupt
-  // ResendRequest packet logs+drops instead of propagating through
-  // the executor and killing the bridge. The ResendRequest.msg comment
-  // promises this; the catch makes the promise true. Mirror the same
-  // pattern at other decode* sites in a follow-up — see the parallel
-  // gap in decodeMessageInternal (predates this change).
+  // Catch deserialization failure here for diagnostic clarity on
+  // the coordinated-redeploy / mismatched-schema scenario. Executor
+  // survival is already provided by UDPBridge::decode's outer
+  // catch-all (udp_bridge.cpp:568-614), which logs an ERROR and
+  // continues for any exception thrown by a decode* path. What this
+  // inner catch buys is a more specific WARN that names this site
+  // ("Failed to deserialize ResendRequest from <node> (<host>:
+  // <port>)") instead of the outer's generic
+  // "decoding error on packet of type N from <node>" — useful when
+  // an operator is chasing a known coordinated-redeploy mismatch
+  // and wants to confirm it's the ResendRequest schema that's
+  // out of sync. The ResendRequest.msg comment documents this
+  // site-specific contract. Mirror the pattern at other decode*
+  // sites in a follow-up only if the diagnostic-clarity payoff is
+  // worth the duplication — see the parallel gap in
+  // decodeMessageInternal (predates this change); the outer catch
+  // is enough for survival there too.
   ResendRequest rr;
   try
   {

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -1171,10 +1171,12 @@ void UDPBridge::resendMissingPackets()
       rr.connection_id.assign(connection->id(), 0,
                               maximum_connection_id_size - 1);
       RemoteConnectionsList rcl;
-      // RemoteConnectionsList is consumed sender-side via
-      // RemoteNode::connection(id) on this bridge's own connections_
-      // (which is keyed on the full pre-truncation id from config), so
-      // the routing list keeps the full string.
+      // Route via the same connection on this bridge's connections_.
+      // Post-PR #25 round-10, `connection->id()` is already the
+      // canonical (truncated) wire form and `RemoteNode::connection()`
+      // canonicalizes its lookup input, so either form works — we use
+      // `connection->id()` for consistency with the rr.connection_id
+      // stamp above.
       rcl[remote.first] = {connection->id()};
       send(rr, rcl, true);
     }

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -798,8 +798,8 @@ void UDPBridge::decodeResendRequest(std::vector<uint8_t> const &message, const S
   // Catch deserialization failure here for diagnostic clarity on
   // the coordinated-redeploy / mismatched-schema scenario. Executor
   // survival is already provided by UDPBridge::decode's outer
-  // catch-all (udp_bridge.cpp:568-614), which logs an ERROR and
-  // continues for any exception thrown by a decode* path. What this
+  // catch-all, which logs an ERROR and continues for any exception
+  // thrown by a decode* path. What this
   // inner catch buys is a more specific WARN that names this site
   // ("Failed to deserialize ResendRequest from <node> (<host>:
   // <port>)") instead of the outer's generic

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -697,17 +697,21 @@ void UDPBridge::decodeResendRequest(std::vector<uint8_t> const &message, const S
   auto rr = deserialize<ResendRequest>(message);
   auto now = get_clock()->now();
 
-  std::vector<std::shared_ptr<Connection>> connections;
+  // Issue #23: route the resend response back via the single connection
+  // the request was stamped for, not a broadcast across every active path.
+  // The routing logic lives on RemoteNode (which owns the connection map);
+  // we snapshot the RemoteNode shared_ptr here under remote_nodes_mutex_
+  // and call dispatchResendRequest outside the lock so its socket I/O
+  // doesn't run under our map mutex.
+  std::shared_ptr<RemoteNode> remote_node;
   {
     std::lock_guard<std::mutex> lock(remote_nodes_mutex_);
-    auto remote_node = remote_nodes_.find(source_info.node_name);
-    if(remote_node != remote_nodes_.end() && remote_node->second)
-      connections = remote_node->second->connections();
+    auto it = remote_nodes_.find(source_info.node_name);
+    if(it != remote_nodes_.end())
+      remote_node = it->second;
   }
-  // resend_packets does network I/O — call without remote_nodes_mutex_ held.
-  for(auto& connection: connections)
-    if(connection)
-      connection->resend_packets(rr.missing_packets, socket_, now);
+  if(remote_node)
+    remote_node->dispatchResendRequest(rr, socket_, now);
 }
 
 void UDPBridge::decodeTopicStatistics(std::vector<uint8_t> const &message, const SourceInfo& source_info)
@@ -964,22 +968,46 @@ void UDPBridge::decodeConnection(std::vector<uint8_t> const &message, const Sour
 
 void UDPBridge::resendMissingPackets()
 {
-  // Snapshot remotes under the lock; getMissingPackets and send() run unlocked.
+  // Snapshot remotes under the lock; getMissingPackets, connections(),
+  // and send() run unlocked.
   std::vector<std::pair<std::string, std::shared_ptr<RemoteNode>>> remotes;
   {
     std::lock_guard<std::mutex> lock(remote_nodes_mutex_);
     remotes.assign(remote_nodes_.begin(), remote_nodes_.end());
   }
   for(auto remote: remotes)
-    if(remote.second)
+  {
+    if(!remote.second)
+      continue;
+    auto rr_base = remote.second->getMissingPackets();
+    if(rr_base.missing_packets.empty())
+      continue;
+    // Issue #23: stamp one copy per live connection and send each via
+    // a RemoteConnectionsList that names only that connection — so the
+    // remote bridge gets one ResendRequest per path and can route the
+    // response back via the same path it arrived on (via
+    // RemoteNode::dispatchResendRequest on the receive side). Replaces
+    // the previous broadcast-to-all-connections send, which amplified
+    // resend volume 2-4x in the both-paths-alive and one-path-dead
+    // regimes documented in the issue.
+    auto connections = remote.second->connections();
+    if(connections.empty())
+      continue;
+    RCLCPP_DEBUG_STREAM(get_logger(),
+      "Sending a request to resend " << rr_base.missing_packets.size()
+      << " packets to " << remote.first << " across "
+      << connections.size() << " connection(s)");
+    for(const auto& connection: connections)
     {
-      auto rr = remote.second->getMissingPackets();
-      if(!rr.missing_packets.empty())
-      {
-        RCLCPP_DEBUG_STREAM(get_logger(), "Sending a request to resend " << rr.missing_packets.size() << " packets");
-        send(rr, remote.first, true);
-      }
+      if(!connection)
+        continue;
+      ResendRequest rr = rr_base;
+      rr.connection_id = connection->id();
+      RemoteConnectionsList rcl;
+      rcl[remote.first] = {connection->id()};
+      send(rr, rcl, true);
     }
+  }
 }
 
 

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -694,7 +694,25 @@ void UDPBridge::decodeBridgeInfo(std::vector<uint8_t> const &message, const Sour
 
 void UDPBridge::decodeResendRequest(std::vector<uint8_t> const &message, const SourceInfo& source_info)
 {
-  auto rr = deserialize<ResendRequest>(message);
+  // Catch deserialization failure here so a mismatched/corrupt
+  // ResendRequest packet logs+drops instead of propagating through
+  // the executor and killing the bridge. The ResendRequest.msg comment
+  // promises this; the catch makes the promise true. Mirror the same
+  // pattern at other decode* sites in a follow-up — see the parallel
+  // gap in decodeMessageInternal (predates this change).
+  ResendRequest rr;
+  try
+  {
+    rr = deserialize<ResendRequest>(message);
+  }
+  catch(const std::exception& e)
+  {
+    RCLCPP_WARN_STREAM(get_logger(),
+      "Failed to deserialize ResendRequest from " << source_info.node_name
+      << " (" << source_info.host << ":" << source_info.port
+      << "): " << e.what() << " — dropping packet");
+    return;
+  }
   auto now = get_clock()->now();
 
   // Issue #23: route the resend response back via the single connection
@@ -1002,8 +1020,24 @@ void UDPBridge::resendMissingPackets()
       if(!connection)
         continue;
       ResendRequest rr = rr_base;
-      rr.connection_id = connection->id();
+      // Honor the on-wire connection-id limit. SequencedPacketHeader
+      // carries a fixed `char connection_id[maximum_connection_id_size]`
+      // (packet.h:82) and WrappedPacket truncates to
+      // `maximum_connection_id_size - 1` (wrapped_packet.cpp:31-32). The
+      // receiver's connections_ map is therefore keyed on the truncated
+      // id (populated via RemoteNode::unwrap from the packet header).
+      // Stamping the full std::string here would cause the receiver's
+      // dispatchResendRequest lookup to miss for any id ≥
+      // maximum_connection_id_size characters — a silent resend-routing
+      // failure that the previous broadcast behavior masked. Truncate
+      // to match the wire format the receiver actually sees.
+      rr.connection_id.assign(connection->id(), 0,
+                              maximum_connection_id_size - 1);
       RemoteConnectionsList rcl;
+      // RemoteConnectionsList is consumed sender-side via
+      // RemoteNode::connection(id) on this bridge's own connections_
+      // (which is keyed on the full pre-truncation id from config), so
+      // the routing list keeps the full string.
       rcl[remote.first] = {connection->id()};
       send(rr, rcl, true);
     }

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -724,12 +724,14 @@ void UDPBridge::decodeResendRequest(std::vector<uint8_t> const &message, const S
   //      lets its resend route correctly (the truncated form matches
   //      what arrived in the packet header).
   //   2) RemoteNode::dispatch_miss_warned_ids_ inserts rr.connection_id
-  //      on lookup miss and is never pruned. Without a receive-side
-  //      cap, a misbehaving peer or a stream of bit-flipped-but-
-  //      deserializable packets could grow the set unboundedly. The
-  //      ROS string field is unbounded at the schema level. Clamping
-  //      ties the practical bound to the configured id space, which
-  //      is what the field comment at remote_node.h claims.
+  //      on lookup miss. Round-4 (PR #25) replaced the unbounded
+  //      std::set with a FIFO capped at kDispatchMissWarnedCap, so the
+  //      bookkeeping count is bounded by code. The receive-side clamp
+  //      remains useful on top of that cap: it bounds each table
+  //      entry's *size* to 7 bytes so the table stays small even at
+  //      full capacity, and it normalizes incoming ids so the
+  //      bookkeeping doesn't double-track an id under its truncated
+  //      and untruncated forms.
   if(rr.connection_id.size() > maximum_connection_id_size - 1)
     rr.connection_id.resize(maximum_connection_id_size - 1);
   auto now = get_clock()->now();

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -713,6 +713,25 @@ void UDPBridge::decodeResendRequest(std::vector<uint8_t> const &message, const S
       << "): " << e.what() << " — dropping packet");
     return;
   }
+  // Enforce the on-wire connection-id limit on the receive side too.
+  // The sender already truncates to maximum_connection_id_size - 1
+  // (udp_bridge.cpp resendMissingPackets) because the receiver's
+  // connections_ map is keyed on the truncated id (packet header is a
+  // fixed char[maximum_connection_id_size]; see wrapped_packet.cpp:31-32).
+  // Clamping here closes two latent gaps:
+  //   1) An older or buggy peer that stamps the full untruncated id
+  //      would otherwise miss the dispatch lookup forever; clamping
+  //      lets its resend route correctly (the truncated form matches
+  //      what arrived in the packet header).
+  //   2) RemoteNode::dispatch_miss_warned_ids_ inserts rr.connection_id
+  //      on lookup miss and is never pruned. Without a receive-side
+  //      cap, a misbehaving peer or a stream of bit-flipped-but-
+  //      deserializable packets could grow the set unboundedly. The
+  //      ROS string field is unbounded at the schema level. Clamping
+  //      ties the practical bound to the configured id space, which
+  //      is what the field comment at remote_node.h claims.
+  if(rr.connection_id.size() > maximum_connection_id_size - 1)
+    rr.connection_id.resize(maximum_connection_id_size - 1);
   auto now = get_clock()->now();
 
   // Issue #23: route the resend response back via the single connection

--- a/udp_bridge/src/udp_bridge.cpp
+++ b/udp_bridge/src/udp_bridge.cpp
@@ -825,18 +825,20 @@ void UDPBridge::decodeResendRequest(std::vector<uint8_t> const &message, const S
       << "): " << e.what() << " — dropping packet");
     return;
   }
-  // Enforce the on-wire connection-id limit on the receive side too.
-  // The sender already truncates to maximum_connection_id_size - 1
-  // (udp_bridge.cpp resendMissingPackets) because the receiver's
-  // connections_ map is keyed on the truncated id (packet header is a
-  // fixed char[maximum_connection_id_size]; see wrapped_packet.cpp:31-32).
-  // Clamping here closes two latent gaps:
-  //   1) An older or buggy peer that stamps the full untruncated id
-  //      would otherwise miss the dispatch lookup forever; clamping
-  //      lets its resend route correctly (the truncated form matches
-  //      what arrived in the packet header).
+  // Normalize the incoming id to the canonical wire form. Well-behaved
+  // peers send canonical ids by construction: PR #25's truncation-
+  // contract change runs every connection-id through
+  // truncate_connection_id at insertion (RemoteNode::newConnection and
+  // Connection::Connection), so connection->id() is canonical and the
+  // sender's stamp at resendMissingPackets is canonical too. Clamping
+  // here defends against a misbehaving peer or an older bridge that
+  // stamps the full untruncated id; without it:
+  //   1) The dispatch lookup against the canonical-keyed connections_
+  //      map would miss for any id ≥ maximum_connection_id_size — a
+  //      silent resend-routing failure. Clamping rewrites the stamp
+  //      to the canonical form so dispatch finds the connection.
   //   2) RemoteNode::dispatch_miss_warned_ids_ inserts rr.connection_id
-  //      on lookup miss. Round-4 (PR #25) replaced the unbounded
+  //      on a lookup miss. Round-4 (PR #25) replaced the unbounded
   //      std::set with a FIFO capped at kDispatchMissWarnedCap, so the
   //      bookkeeping count is bounded by code. The receive-side clamp
   //      remains useful on top of that cap: it bounds each table
@@ -1156,14 +1158,16 @@ void UDPBridge::resendMissingPackets()
       // Honor the on-wire connection-id limit. SequencedPacketHeader
       // carries a fixed `char connection_id[maximum_connection_id_size]`
       // (packet.h:82) and WrappedPacket truncates to
-      // `maximum_connection_id_size - 1` (wrapped_packet.cpp:31-32). The
-      // receiver's connections_ map is therefore keyed on the truncated
-      // id (populated via RemoteNode::unwrap from the packet header).
-      // Stamping the full std::string here would cause the receiver's
-      // dispatchResendRequest lookup to miss for any id ≥
-      // maximum_connection_id_size characters — a silent resend-routing
-      // failure that the previous broadcast behavior masked. Truncate
-      // to match the wire format the receiver actually sees.
+      // `maximum_connection_id_size - 1` (wrapped_packet.cpp:31-32). As
+      // of the truncation-contract canonicalization (PR #25), every
+      // path that inserts into connections_ runs the id through
+      // truncate_connection_id at construction (RemoteNode::newConnection
+      // and Connection::Connection), so `connection->id()` is already
+      // canonical here — the assign-with-substring below is a defensive
+      // no-op in the canonical-id steady state. Kept so a future
+      // refactor that lets a longer-than-7 id reach this point still
+      // can't desync the wire stamp from the canonical key the receiver
+      // is keying its connections_ map on.
       rr.connection_id.assign(connection->id(), 0,
                               maximum_connection_id_size - 1);
       RemoteConnectionsList rcl;

--- a/udp_bridge/test/test_remote_node_resend.cpp
+++ b/udp_bridge/test/test_remote_node_resend.cpp
@@ -458,27 +458,36 @@ TEST_F(ResendFixture, BurstLossAllGapsFlagTogetherAfterDebounce)
 // which amplified resend volume 2-4x and pushed bytes into rx-dead paths
 // under the 2026-05-19 wifi-loss storm.
 //
-// Four tests below cover the matched-id case, the two flavors of the
-// "stamped id is absent from the receiver's connections_" path, and the
-// connection-id-length truncation contract:
-//   - StampedIdAbsent: receiver currently knows about a subset of the
-//     connection ids the sender knows about. Models the transient
-//     post-restart / pre-BridgeInfo-reconciliation window where the
-//     sender stamps for an id the receiver hasn't (re-)registered yet.
-//   - UnknownConnectionId: stamped id was never registered on the
-//     receiver at all. Models a config-mismatch coordinated-redeploy bug
-//     where the two bridges' connection-id strings don't agree.
-//   - TruncatedConnectionIdMatches: the sender truncates to
-//     maximum_connection_id_size - 1 chars when stamping; the receiver's
-//     connections_ map is keyed on the truncated id (packet header is a
-//     fixed char array). The truncated-form lookup matches; the
-//     untruncated-form lookup misses. This is the contract the fix in
-//     UDPBridge::resendMissingPackets relies on.
-// The two no-op cases share dispatch's lookup-miss branch (which emits
+// Five tests below cover dispatch routing and the WARN-bookkeeping cap:
+//   - DispatchRoutesToStampedConnectionOnly: the matched-id case — a
+//     request stamped for "wifi" reaches only the wifi connection's
+//     resend_packets, not vpn's.
+//   - DispatchDropsWithoutBroadcastWhenStampedIdAbsent: receiver knows
+//     a subset of the connection ids the sender knows about. Models
+//     the transient post-restart / pre-BridgeInfo-reconciliation
+//     window where the sender stamps for an id the receiver hasn't
+//     (re-)registered yet.
+//   - DispatchDropsWithoutBroadcastUnknownConnectionId: stamped id was
+//     never registered on the receiver at all. Models a config-mismatch
+//     coordinated-redeploy bug where the two bridges' connection-id
+//     strings don't agree.
+//   - DispatchDoesNotFuzzyMatchConnectionId: dispatch performs a
+//     strict-equality lookup — a request stamped with the untruncated
+//     form of an id already in the map must miss, not be silently
+//     routed via a prefix match. The wire-contract truncation that
+//     gives an in-band form to compare against lives in the private
+//     receive plumbing of UDPBridge (resendMissingPackets / receive-side
+//     clamp in decodeResendRequest); this test pins the dispatch
+//     contract only, not that wire contract.
+//   - DispatchMissWarnedIdsAreBounded: the bookkeeping table that
+//     dedups first-miss WARN logs has a hard cap (kDispatchMissWarnedCap)
+//     with FIFO eviction; a peer streaming distinct ids cannot grow
+//     the table without bound.
+// The lookup-miss cases share dispatch's miss branch (which emits
 // WARN-on-first-miss-per-id, DEBUG thereafter — see
 // dispatchResendRequest in remote_node.cpp). The behavioral invariant
 // these tests assert is "no broadcast fallback to other connections",
-// not "no log output". The test split documents the two operational
+// not "no log output". The test split documents the operational
 // scenarios an operator might be chasing when that WARN/DEBUG log fires.
 
 namespace

--- a/udp_bridge/test/test_remote_node_resend.cpp
+++ b/udp_bridge/test/test_remote_node_resend.cpp
@@ -33,9 +33,12 @@
 #include "rcutils/logging.h"
 
 #include "udp_bridge_interfaces/msg/resend_request.hpp"
+#include "udp_bridge_interfaces/msg/remote.hpp"
+#include "udp_bridge_interfaces/msg/remote_connection.hpp"
 #include "udp_bridge/connection.h"
 #include "udp_bridge/remote_node.h"
 #include "udp_bridge/resend_constants.h"
+#include "udp_bridge/packet.h"   // truncate_connection_id, maximum_connection_id_size
 
 namespace
 {
@@ -458,7 +461,7 @@ TEST_F(ResendFixture, BurstLossAllGapsFlagTogetherAfterDebounce)
 // which amplified resend volume 2-4x and pushed bytes into rx-dead paths
 // under the 2026-05-19 wifi-loss storm.
 //
-// Six tests below cover dispatch routing, the canonical-id contract,
+// Eight tests below cover dispatch routing, the canonical-id contract,
 // and the WARN-bookkeeping cap:
 //   - DispatchRoutesToStampedConnectionOnly: the matched-id case — a
 //     request stamped for "wifi" reaches only the wifi connection's
@@ -483,6 +486,17 @@ TEST_F(ResendFixture, BurstLossAllGapsFlagTogetherAfterDebounce)
 //     truncated to the wire form at construction time, so a sender
 //     stamping the canonical form lands on the connection that owns
 //     sent_packets_ for that link.
+//   - UpdateRemoteWithLongIdDoesNotOrphanOrClobber: drives the
+//     RemoteNode::update(const Remote&) path with a long configured
+//     id and asserts no orphan untruncated-key entry is created and
+//     that a second update call doesn't replace the existing
+//     Connection instance (regression for the bare-operator[] bug
+//     R9 flagged on round-10).
+//   - NewConnectionRejectsCanonicalIdCollision: two distinct
+//     configured ids that share the first 7 chars (canonicalize to
+//     the same wire form) — the second call must return the
+//     first-registered Connection rather than constructing a fresh
+//     one and clobbering the entry.
 //   - DispatchMissWarnedIdsAreBounded: the bookkeeping table that
 //     dedups first-miss WARN logs has a hard cap (kDispatchMissWarnedCap)
 //     with FIFO eviction; a peer streaming distinct ids cannot grow
@@ -696,6 +710,108 @@ TEST_F(ResendFixture, NewConnectionCanonicalizesLongId)
     << "Canonical-form stamp must route to the connection created from "
        "the long configured id. A miss here means the truncation "
        "contract is back to one-sided.";
+}
+
+// Regression for Copilot R9 finding (PR #25): RemoteNode::update(const
+// Remote&) used a bare `connections_[c.connection_id]` index with the
+// untruncated configured id. For ids ≥ maximum_connection_id_size the
+// canonical key from newConnection() and the untruncated key from
+// operator[] were distinct, leaving a null-shared_ptr orphan slot at
+// the untruncated key and (more dangerously) re-entering newConnection's
+// overwrite path on every subsequent update — which clobbered the live
+// Connection's sent_packets_ / stats. This test drives the
+// update(Remote) path with a long configured id and asserts:
+//   - the canonical-keyed Connection exists,
+//   - no orphan slot lives at the untruncated key
+//     (RemoteNode::connection(untruncated) finds the canonical one,
+//     not an orphan null),
+//   - a second update(Remote) call returns the same Connection
+//     instance (no clobber).
+TEST_F(ResendFixture, UpdateRemoteWithLongIdDoesNotOrphanOrClobber)
+{
+  const std::string full_id = "starlink";   // 8 chars (>= max)
+  const std::string canonical_id = "starlin";
+
+  udp_bridge_interfaces::msg::Remote remote_msg;
+  remote_msg.name = "test-remote";  // matches the fixture's RemoteNode name_
+  udp_bridge_interfaces::msg::RemoteConnection rc;
+  rc.connection_id = full_id;
+  rc.host = "127.0.0.1";
+  rc.port = 9201;
+  rc.maximum_bytes_per_second = 1000000;
+  remote_msg.connections.push_back(rc);
+
+  remote_->update(remote_msg);
+
+  // The Connection landed at the canonical key.
+  auto via_canonical = remote_->connection(canonical_id);
+  ASSERT_NE(via_canonical, nullptr) << "update(Remote) did not create a "
+    "Connection at the canonical key — canonicalization isn't being "
+    "applied on this path.";
+  EXPECT_EQ(via_canonical->id(), canonical_id);
+
+  // Lookup via the untruncated configured id finds the same Connection
+  // (because RemoteNode::connection canonicalizes its input). If the
+  // bare-operator[] regression were back, this would either return
+  // a different shared_ptr (orphan null at untruncated key) or be
+  // unequal to via_canonical.
+  auto via_full = remote_->connection(full_id);
+  EXPECT_EQ(via_full, via_canonical) << "RemoteNode::connection lookup "
+    "with the untruncated configured id must canonicalize and land on "
+    "the same Connection instance.";
+
+  // Second update — must NOT clobber. We can't observe sent_packets_
+  // directly from the public API, but a clobber would replace the
+  // shared_ptr with a freshly-constructed Connection at the same
+  // canonical key. Pointer equality after a second update proves the
+  // entry survived.
+  auto* expected_raw = via_canonical.get();
+  remote_->update(remote_msg);
+  auto via_canonical_after = remote_->connection(canonical_id);
+  ASSERT_NE(via_canonical_after, nullptr);
+  EXPECT_EQ(via_canonical_after.get(), expected_raw)
+    << "Second update(Remote) replaced the live Connection at the "
+       "canonical key — newConnection's overwrite path was re-entered, "
+       "which would have wiped sent_packets_ / received-rate state in "
+       "production.";
+}
+
+// Regression for Copilot R9 finding (PR #25): newConnection's
+// unconditional `connections_[canonical_id] = make_shared(...)` would
+// silently clobber an existing Connection when two distinct configured
+// ids share the first `maximum_connection_id_size - 1` chars and so
+// collide under the canonical form. This test creates a Connection
+// under "starlink", then asks for one under "starlink-vp" (same
+// canonical "starlin", different host/port). The expected behavior:
+// the first Connection survives, the second is rejected with an ERROR
+// log, and the existing Connection is returned to the caller.
+TEST_F(ResendFixture, NewConnectionRejectsCanonicalIdCollision)
+{
+  auto first = remote_->newConnection("starlink", "127.0.0.1", 9301);
+  ASSERT_NE(first, nullptr);
+  EXPECT_EQ(first->id(), "starlin");
+  EXPECT_EQ(first->host(), "127.0.0.1");
+  EXPECT_EQ(first->port(), 9301u);
+
+  // "starlink-vp" also canonicalizes to "starlin". newConnection must
+  // return the existing first-registered Connection rather than
+  // constructing a second one and clobbering the entry.
+  auto second = remote_->newConnection("starlink-vp", "192.168.42.1", 9302);
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(second.get(), first.get())
+    << "Second newConnection call with a different configured id that "
+       "collides under the canonical form must return the existing "
+       "Connection, not replace it.";
+  // Existing host/port preserved — clobber would have moved these.
+  EXPECT_EQ(first->host(), "127.0.0.1");
+  EXPECT_EQ(first->port(), 9301u);
+
+  // Idempotent same-input case: calling with the original full id and
+  // matching host/port should also return the same Connection without
+  // logging an ERROR (the "caller missed a connection() lookup" path).
+  auto third = remote_->newConnection("starlink", "127.0.0.1", 9301);
+  ASSERT_NE(third, nullptr);
+  EXPECT_EQ(third.get(), first.get());
 }
 
 // Routing case 6: bookkeeping cap. dispatchResendRequest tracks

--- a/udp_bridge/test/test_remote_node_resend.cpp
+++ b/udp_bridge/test/test_remote_node_resend.cpp
@@ -472,9 +472,12 @@ TEST_F(ResendFixture, BurstLossAllGapsFlagTogetherAfterDebounce)
 //     fixed char array). The truncated-form lookup matches; the
 //     untruncated-form lookup misses. This is the contract the fix in
 //     UDPBridge::resendMissingPackets relies on.
-// The two no-op cases share dispatch's lookup-miss branch; the test
-// split documents the two operational scenarios an operator might be
-// chasing when the WARN/DEBUG log fires.
+// The two no-op cases share dispatch's lookup-miss branch (which emits
+// WARN-on-first-miss-per-id, DEBUG thereafter — see
+// dispatchResendRequest in remote_node.cpp). The behavioral invariant
+// these tests assert is "no broadcast fallback to other connections",
+// not "no log output". The test split documents the two operational
+// scenarios an operator might be chasing when that WARN/DEBUG log fires.
 
 namespace
 {
@@ -528,9 +531,11 @@ TEST_F(ResendFixture, DispatchRoutesToStampedConnectionOnly)
 // Routing case 2: stamped id is absent from the receiver's connections_
 // (subset state). Models the race window where the receiver hasn't
 // re-registered the connection yet but the sender already stamped for
-// it. Dispatch must no-op silently — must not fall back to broadcast
-// (that's the old behavior this issue removes).
-TEST_F(ResendFixture, DispatchSilentlyDropsWhenStampedIdAbsent)
+// it. Dispatch must no-op (no broadcast fallback to other live
+// connections — that's the old behavior this issue removes). Dispatch
+// also emits a WARN log on the first such miss per id; this test
+// asserts the routing invariant, not the log output.
+TEST_F(ResendFixture, DispatchDropsWithoutBroadcastWhenStampedIdAbsent)
 {
   // Receiver knows only "vpn" right now; sender stamped for "wifi".
   auto vpn = remote_->newConnection("vpn", "127.0.0.1", 9002);
@@ -550,9 +555,10 @@ TEST_F(ResendFixture, DispatchSilentlyDropsWhenStampedIdAbsent)
 }
 
 // Routing case 3: stamped id was never registered (config mismatch
-// across coordinated redeploys). Same no-op path as case 2; differs in
-// known_ids log content (which is operator-facing, not asserted here).
-TEST_F(ResendFixture, DispatchSilentlyDropsUnknownConnectionId)
+// across coordinated redeploys). Same no-broadcast-fallback invariant
+// as case 2; differs in known_ids log content (which is operator-facing,
+// not asserted here).
+TEST_F(ResendFixture, DispatchDropsWithoutBroadcastUnknownConnectionId)
 {
   auto wifi = remote_->newConnection("wifi", "127.0.0.1", 9001);
   auto vpn  = remote_->newConnection("vpn",  "127.0.0.1", 9002);

--- a/udp_bridge/test/test_remote_node_resend.cpp
+++ b/udp_bridge/test/test_remote_node_resend.cpp
@@ -579,22 +579,34 @@ TEST_F(ResendFixture, DispatchDropsWithoutBroadcastUnknownConnectionId)
   EXPECT_EQ(vpn->resend_call_count_for_test(),  0u);
 }
 
-// Routing case 4: connection-id-length truncation contract. The
-// on-wire SequencedPacketHeader carries
-// `char connection_id[maximum_connection_id_size]` (8 bytes), and
-// WrappedPacket truncates to 7 chars + null when constructing that
-// header (wrapped_packet.cpp:31-32). The receiver's connections_ map
-// is therefore keyed on the truncated id. UDPBridge::resendMissingPackets
-// must stamp the ResendRequest with the truncated id so dispatch's
-// lookup matches what the receiver actually has. This test exercises
-// the dispatch side of that contract: when the sender does the right
-// thing (truncated id), dispatch resolves; when it does the wrong
-// thing (full id ≥ 8 chars), dispatch misses. A regression that
-// reintroduces the full-id stamp would surface as the second
-// assertion succeeding when it shouldn't — but more importantly,
-// would cause silent resend-routing failure in production for any
-// configured id longer than 7 chars (e.g. "starlink", "cellular").
-TEST_F(ResendFixture, DispatchHonorsTruncatedConnectionId)
+// Routing case 4: dispatch is strict-match — it does not fuzzy-match
+// or auto-truncate. The receiver's connections_ map is keyed on the
+// truncated id (the on-wire SequencedPacketHeader is a fixed
+// char[maximum_connection_id_size]; WrappedPacket truncates to 7
+// chars + null at wrapped_packet.cpp:31-32, and connections_ is
+// populated from packet headers). Dispatch looks up
+// connections_[rr.connection_id] exactly — no prefix match, no
+// length normalization.
+//
+// Scope note: this test verifies the dispatch-side strict-match
+// invariant only. The full wire contract — "any id longer than 7
+// chars routes correctly in production" — is enforced by the
+// combination of (a) sender-side truncation in
+// UDPBridge::resendMissingPackets and (b) receive-side clamp in
+// UDPBridge::decodeResendRequest, both of which apply BEFORE
+// dispatchResendRequest is called. Neither has a dedicated unit
+// test because both are inside the private wire-decode plumbing of
+// UDPBridge; their integration is verified by the package's
+// end-to-end resend behavior in the field rather than at this seam.
+// A regression that re-introduces the pre-fix bug (sender stamps
+// the full untruncated id) would still route correctly today
+// because the receive-side clamp would normalize the id before
+// reaching dispatch. So a strict regression test for the wire
+// contract would require either a friend-declared test entry to
+// decodeResendRequest or a wire-format integration test that
+// constructs and dispatches a real packet — both out of scope for
+// this unit suite.
+TEST_F(ResendFixture, DispatchDoesNotFuzzyMatchConnectionId)
 {
   // The receiver's connection key is the truncated form (what would
   // arrive in the wire packet header). "starlink" (8 chars) becomes
@@ -606,28 +618,29 @@ TEST_F(ResendFixture, DispatchHonorsTruncatedConnectionId)
   ASSERT_GE(sock.get(), 0);
 
   {
-    // Sender stamped the truncated form (the fix's behavior).
+    // Exact-match: rr stamped with the truncated key → routes.
     udp_bridge_interfaces::msg::ResendRequest rr;
     rr.missing_packets = {1u};
     rr.connection_id = "starlin";
     remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0));
     EXPECT_EQ(truncated->resend_call_count_for_test(), 1u)
-      << "Truncated-form stamp must match the truncated-form receiver "
-         "key (the post-fix wire contract).";
+      << "Exact-key stamp must match the connection's key.";
   }
   {
-    // Sender stamped the full untruncated form (the pre-fix bug).
-    // Lookup misses because connections_["starlink"] doesn't exist;
-    // counter must not bump.
+    // No fuzzy match: rr stamped with the untruncated form — even
+    // though "starlink" begins with "starlin", dispatch must do a
+    // strict equality lookup. If a future refactor introduces
+    // prefix-match behavior at the dispatch site, this counter
+    // bumps and the test fails — surfacing the change before it
+    // can silently mis-route a forged id.
     udp_bridge_interfaces::msg::ResendRequest rr;
     rr.missing_packets = {1u};
     rr.connection_id = "starlink";
     remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0));
     EXPECT_EQ(truncated->resend_call_count_for_test(), 1u)
-      << "Untruncated-form stamp must miss the truncated-form receiver "
-         "key. A regression that bumps the counter here means the wire "
-         "contract is broken — any id longer than 7 chars silently "
-         "loses resends in the field.";
+      << "Dispatch lookup must be strict-equality. A counter bump "
+         "here would mean dispatch is fuzzy-matching ids, which "
+         "could mis-route a forged or stale id to a real connection.";
   }
 }
 
@@ -686,20 +699,38 @@ TEST_F(ResendFixture, DispatchMissWarnedIdsAreBounded)
   // warn/error/fatal), so the cast is well-defined.
   logger.set_level(static_cast<rclcpp::Logger::Level>(prev_level));
 
-  // After pushing kPushCount distinct ids, the bookkeeping must have
-  // stopped growing well below kPushCount. The exact ceiling is the
-  // implementation's cap; we just assert it's bounded.
+  // After pushing kPushCount distinct ids, the bookkeeping must
+  // hold exactly the cap (we pushed kPushCount > cap, so it must
+  // saturate to the cap value). Importing the constant directly
+  // here is a small coupling to implementation, but it lets the
+  // test catch a "doubled cap" regression that the previous loose
+  // ceiling (<= 512u) would have permitted.
   std::size_t count = remote_->dispatchMissWarnedIdCountForTest();
-  EXPECT_LT(count, kPushCount)
-    << "Bookkeeping grew with every distinct id — the cap is missing "
-       "or broken. A misbehaving peer could now drive memory growth.";
-  EXPECT_LE(count, 512u)
-    << "Bookkeeping size exceeded a generous upper bound. Cap is "
-       "likely much larger than intended (or absent).";
-  EXPECT_GE(count, 1u)
-    << "Bookkeeping is empty — the WARN-once path didn't insert "
-       "anything. The dispatch lookup-miss branch is probably not "
-       "being exercised.";
+  EXPECT_EQ(count, udp_bridge::RemoteNode::dispatchMissWarnedCapForTest())
+    << "Bookkeeping size does not match the configured cap. Either "
+       "the cap regressed (likely doubled), or eviction failed to "
+       "run at the right boundary.";
+
+  // FIFO order check: of the kPushCount ids inserted in sequence,
+  // the most-recently-pushed should still be in the table (it was
+  // just inserted at the tail), and the earliest pushed ids should
+  // have been evicted (they fell off the head when the table
+  // saturated). A regression that evicted from the tail instead of
+  // the head — or evicted arbitrarily — would still satisfy the
+  // size assertion above but would fail these.
+  char head_id[8];   // earliest inserted (should be evicted)
+  char tail_id[8];   // most recent (should be retained)
+  std::snprintf(head_id, sizeof(head_id), "m%05zu", static_cast<std::size_t>(0));
+  std::snprintf(tail_id, sizeof(tail_id), "m%05zu", kPushCount - 1);
+  EXPECT_FALSE(remote_->isDispatchMissWarnedForTest(head_id))
+    << "Earliest-inserted id (" << head_id << ") is still in the "
+       "bookkeeping after pushing kPushCount > cap entries. FIFO "
+       "eviction is broken — likely evicting from the tail or "
+       "evicting arbitrarily.";
+  EXPECT_TRUE(remote_->isDispatchMissWarnedForTest(tail_id))
+    << "Most-recently-inserted id (" << tail_id << ") is missing "
+       "from the bookkeeping. Insert is broken — or eviction "
+       "happened immediately after insert.";
 }
 
 int main(int argc, char** argv)

--- a/udp_bridge/test/test_remote_node_resend.cpp
+++ b/udp_bridge/test/test_remote_node_resend.cpp
@@ -21,6 +21,7 @@
 // matches the clock RemoteNode itself would observe under sim time.
 
 #include <cstdint>
+#include <cstdio>
 #include <vector>
 
 #include <sys/socket.h>
@@ -627,6 +628,57 @@ TEST_F(ResendFixture, DispatchHonorsTruncatedConnectionId)
          "contract is broken — any id longer than 7 chars silently "
          "loses resends in the field.";
   }
+}
+
+// Routing case 5: bookkeeping cap. dispatchResendRequest tracks
+// already-WARNed ids in a bounded FIFO to keep memory pressure
+// proportional to the configured connection-id space, not to whatever
+// the peer sends (a peer that streamed many distinct ids could
+// otherwise grow the table without bound — see the field comment on
+// dispatch_miss_warned_ids_ in remote_node.h). This test pumps more
+// distinct ids than the cap and asserts the table size stops growing.
+// The "ids each cause one dispatch call" wiring is irrelevant here —
+// no connection is registered, so every dispatch is a lookup miss,
+// which is exactly the path we're stressing.
+TEST_F(ResendFixture, DispatchMissWarnedIdsAreBounded)
+{
+  // The implementation cap is RemoteNode::kDispatchMissWarnedCap (256
+  // at the time of writing). We don't import the constant directly —
+  // the assertion is "size stays <= the cap and converges to the cap
+  // when we push past it", expressed in terms of the count returned
+  // by dispatchMissWarnedIdCountForTest(). The specific cap value is
+  // an implementation choice, not a wire contract.
+  ScopedFd sock;
+  ASSERT_GE(sock.get(), 0);
+
+  const std::size_t kPushCount = 1024;  // safely past any reasonable cap
+  for(std::size_t i = 0; i < kPushCount; ++i)
+  {
+    udp_bridge_interfaces::msg::ResendRequest rr;
+    rr.missing_packets = {1u};
+    // 7-char ids (the post-clamp wire size). Make each one unique by
+    // appending a small alpha suffix derived from i. The actual
+    // string values don't matter — only that they're distinct.
+    char id[8];
+    std::snprintf(id, sizeof(id), "m%05zu", i % 100000);
+    rr.connection_id = id;
+    remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0 + static_cast<double>(i) * 0.001));
+  }
+
+  // After pushing kPushCount distinct ids, the bookkeeping must have
+  // stopped growing well below kPushCount. The exact ceiling is the
+  // implementation's cap; we just assert it's bounded.
+  std::size_t count = remote_->dispatchMissWarnedIdCountForTest();
+  EXPECT_LT(count, kPushCount)
+    << "Bookkeeping grew with every distinct id — the cap is missing "
+       "or broken. A misbehaving peer could now drive memory growth.";
+  EXPECT_LE(count, 512u)
+    << "Bookkeeping size exceeded a generous upper bound. Cap is "
+       "likely much larger than intended (or absent).";
+  EXPECT_GE(count, 1u)
+    << "Bookkeeping is empty — the WARN-once path didn't insert "
+       "anything. The dispatch lookup-miss branch is probably not "
+       "being exercised.";
 }
 
 int main(int argc, char** argv)

--- a/udp_bridge/test/test_remote_node_resend.cpp
+++ b/udp_bridge/test/test_remote_node_resend.cpp
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rcutils/logging.h"
 
 #include "udp_bridge_interfaces/msg/resend_request.hpp"
 #include "udp_bridge/connection.h"
@@ -651,7 +652,21 @@ TEST_F(ResendFixture, DispatchMissWarnedIdsAreBounded)
   ScopedFd sock;
   ASSERT_GE(sock.get(), 0);
 
-  const std::size_t kPushCount = 1024;  // safely past any reasonable cap
+  // Every distinct id in this loop fires a first-miss WARN. To keep
+  // the captured test log readable (and CI fast) we silence the
+  // node's logger for the duration of the push, then restore. The
+  // cap-enforcement assertion uses dispatchMissWarnedIdCountForTest,
+  // not log inspection, so silencing has no effect on what the test
+  // proves.
+  auto logger = node_->get_logger();
+  auto prev_level = rcutils_logging_get_logger_level(logger.get_name());
+  logger.set_level(rclcpp::Logger::Level::Error);
+
+  // 32 above any plausible cap — the test was previously pushing
+  // 1024, which emitted ~1024 WARN lines per run. The cap is 256 at
+  // the time of writing; pushing 288 still proves eviction fires
+  // with comfortable margin (32 distinct evictions exercised).
+  const std::size_t kPushCount = 288;
   for(std::size_t i = 0; i < kPushCount; ++i)
   {
     udp_bridge_interfaces::msg::ResendRequest rr;
@@ -664,6 +679,12 @@ TEST_F(ResendFixture, DispatchMissWarnedIdsAreBounded)
     rr.connection_id = id;
     remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0 + static_cast<double>(i) * 0.001));
   }
+
+  // Restore the prior logger level so subsequent tests behave
+  // normally. RCUTILS_LOG_SEVERITY_* and rclcpp::Logger::Level use
+  // the same integer values (0/10/20/30/40/50 for unset/debug/info/
+  // warn/error/fatal), so the cast is well-defined.
+  logger.set_level(static_cast<rclcpp::Logger::Level>(prev_level));
 
   // After pushing kPushCount distinct ids, the bookkeeping must have
   // stopped growing well below kPushCount. The exact ceiling is the

--- a/udp_bridge/test/test_remote_node_resend.cpp
+++ b/udp_bridge/test/test_remote_node_resend.cpp
@@ -456,8 +456,9 @@ TEST_F(ResendFixture, BurstLossAllGapsFlagTogetherAfterDebounce)
 // which amplified resend volume 2-4x and pushed bytes into rx-dead paths
 // under the 2026-05-19 wifi-loss storm.
 //
-// The three tests below cover one matched-id case and two flavors of the
-// "stamped id is absent from the receiver's connections_" path:
+// Four tests below cover the matched-id case, the two flavors of the
+// "stamped id is absent from the receiver's connections_" path, and the
+// connection-id-length truncation contract:
 //   - StampedIdAbsent: receiver currently knows about a subset of the
 //     connection ids the sender knows about. Models the transient
 //     post-restart / pre-BridgeInfo-reconciliation window where the
@@ -465,17 +466,27 @@ TEST_F(ResendFixture, BurstLossAllGapsFlagTogetherAfterDebounce)
 //   - UnknownConnectionId: stamped id was never registered on the
 //     receiver at all. Models a config-mismatch coordinated-redeploy bug
 //     where the two bridges' connection-id strings don't agree.
-// Both no-op paths share dispatch's lookup-miss branch; the test split
-// documents the two operational scenarios an operator might be chasing
-// when the DEBUG log fires.
+//   - TruncatedConnectionIdMatches: the sender truncates to
+//     maximum_connection_id_size - 1 chars when stamping; the receiver's
+//     connections_ map is keyed on the truncated id (packet header is a
+//     fixed char array). The truncated-form lookup matches; the
+//     untruncated-form lookup misses. This is the contract the fix in
+//     UDPBridge::resendMissingPackets relies on.
+// The two no-op cases share dispatch's lookup-miss branch; the test
+// split documents the two operational scenarios an operator might be
+// chasing when the WARN/DEBUG log fires.
 
 namespace
 {
 
-// Open an unbound UDP socket for the dispatch tests. Connection::send
-// will hand this to sendto(); without a destination address the call
-// fails benignly with EDESTADDRREQ, which is fine — the assertion is
-// the per-connection counter, not the I/O. Caller closes via ScopedFd.
+// Open a real UDP socket for the dispatch tests. Connection::send
+// will hand this to sendto(); the loopback destination resolves to
+// a real port whose receiver is no one, so the kernel cheerfully
+// accepts the datagram. The assertion target is the per-connection
+// counter, NOT the I/O — Connection::resend_packets increments the
+// counter at function entry before any sendto call, so empty payloads
+// or undeliverable destinations don't affect the test outcome. Caller
+// closes via RAII.
 class ScopedFd
 {
 public:
@@ -498,13 +509,6 @@ TEST_F(ResendFixture, DispatchRoutesToStampedConnectionOnly)
   auto vpn  = remote_->newConnection("vpn",  "127.0.0.1", 9002);
   ASSERT_NE(wifi, nullptr);
   ASSERT_NE(vpn,  nullptr);
-
-  // Seed one sent packet on each connection so resend_packets has
-  // something to look up. The lookup result doesn't matter for the
-  // assertion (we count calls, not sent bytes); seeding just exercises
-  // the production code path past its early-return.
-  wifi->record_sent_packet_for_test(1, t_at(1.0));
-  vpn->record_sent_packet_for_test(1, t_at(1.0));
 
   udp_bridge_interfaces::msg::ResendRequest rr;
   rr.missing_packets = {1u};
@@ -531,7 +535,6 @@ TEST_F(ResendFixture, DispatchSilentlyDropsWhenStampedIdAbsent)
   // Receiver knows only "vpn" right now; sender stamped for "wifi".
   auto vpn = remote_->newConnection("vpn", "127.0.0.1", 9002);
   ASSERT_NE(vpn, nullptr);
-  vpn->record_sent_packet_for_test(1, t_at(1.0));
 
   udp_bridge_interfaces::msg::ResendRequest rr;
   rr.missing_packets = {1u};
@@ -555,12 +558,10 @@ TEST_F(ResendFixture, DispatchSilentlyDropsUnknownConnectionId)
   auto vpn  = remote_->newConnection("vpn",  "127.0.0.1", 9002);
   ASSERT_NE(wifi, nullptr);
   ASSERT_NE(vpn,  nullptr);
-  wifi->record_sent_packet_for_test(1, t_at(1.0));
-  vpn->record_sent_packet_for_test(1, t_at(1.0));
 
   udp_bridge_interfaces::msg::ResendRequest rr;
   rr.missing_packets = {1u};
-  rr.connection_id = "starlink";  // never registered on this RemoteNode
+  rr.connection_id = "iridium";  // never registered on this RemoteNode
 
   ScopedFd sock;
   ASSERT_GE(sock.get(), 0);
@@ -568,6 +569,58 @@ TEST_F(ResendFixture, DispatchSilentlyDropsUnknownConnectionId)
 
   EXPECT_EQ(wifi->resend_call_count_for_test(), 0u);
   EXPECT_EQ(vpn->resend_call_count_for_test(),  0u);
+}
+
+// Routing case 4: connection-id-length truncation contract. The
+// on-wire SequencedPacketHeader carries
+// `char connection_id[maximum_connection_id_size]` (8 bytes), and
+// WrappedPacket truncates to 7 chars + null when constructing that
+// header (wrapped_packet.cpp:31-32). The receiver's connections_ map
+// is therefore keyed on the truncated id. UDPBridge::resendMissingPackets
+// must stamp the ResendRequest with the truncated id so dispatch's
+// lookup matches what the receiver actually has. This test exercises
+// the dispatch side of that contract: when the sender does the right
+// thing (truncated id), dispatch resolves; when it does the wrong
+// thing (full id ≥ 8 chars), dispatch misses. A regression that
+// reintroduces the full-id stamp would surface as the second
+// assertion succeeding when it shouldn't — but more importantly,
+// would cause silent resend-routing failure in production for any
+// configured id longer than 7 chars (e.g. "starlink", "cellular").
+TEST_F(ResendFixture, DispatchHonorsTruncatedConnectionId)
+{
+  // The receiver's connection key is the truncated form (what would
+  // arrive in the wire packet header). "starlink" (8 chars) becomes
+  // "starlin" (7 chars + implicit null in the char array).
+  auto truncated = remote_->newConnection("starlin", "127.0.0.1", 9003);
+  ASSERT_NE(truncated, nullptr);
+
+  ScopedFd sock;
+  ASSERT_GE(sock.get(), 0);
+
+  {
+    // Sender stamped the truncated form (the fix's behavior).
+    udp_bridge_interfaces::msg::ResendRequest rr;
+    rr.missing_packets = {1u};
+    rr.connection_id = "starlin";
+    remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0));
+    EXPECT_EQ(truncated->resend_call_count_for_test(), 1u)
+      << "Truncated-form stamp must match the truncated-form receiver "
+         "key (the post-fix wire contract).";
+  }
+  {
+    // Sender stamped the full untruncated form (the pre-fix bug).
+    // Lookup misses because connections_["starlink"] doesn't exist;
+    // counter must not bump.
+    udp_bridge_interfaces::msg::ResendRequest rr;
+    rr.missing_packets = {1u};
+    rr.connection_id = "starlink";
+    remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0));
+    EXPECT_EQ(truncated->resend_call_count_for_test(), 1u)
+      << "Untruncated-form stamp must miss the truncated-form receiver "
+         "key. A regression that bumps the counter here means the wire "
+         "contract is broken — any id longer than 7 chars silently "
+         "loses resends in the field.";
+  }
 }
 
 int main(int argc, char** argv)

--- a/udp_bridge/test/test_remote_node_resend.cpp
+++ b/udp_bridge/test/test_remote_node_resend.cpp
@@ -458,7 +458,8 @@ TEST_F(ResendFixture, BurstLossAllGapsFlagTogetherAfterDebounce)
 // which amplified resend volume 2-4x and pushed bytes into rx-dead paths
 // under the 2026-05-19 wifi-loss storm.
 //
-// Five tests below cover dispatch routing and the WARN-bookkeeping cap:
+// Six tests below cover dispatch routing, the canonical-id contract,
+// and the WARN-bookkeeping cap:
 //   - DispatchRoutesToStampedConnectionOnly: the matched-id case — a
 //     request stamped for "wifi" reaches only the wifi connection's
 //     resend_packets, not vpn's.
@@ -472,13 +473,16 @@ TEST_F(ResendFixture, BurstLossAllGapsFlagTogetherAfterDebounce)
 //     coordinated-redeploy bug where the two bridges' connection-id
 //     strings don't agree.
 //   - DispatchDoesNotFuzzyMatchConnectionId: dispatch performs a
-//     strict-equality lookup — a request stamped with the untruncated
-//     form of an id already in the map must miss, not be silently
-//     routed via a prefix match. The wire-contract truncation that
-//     gives an in-band form to compare against lives in the private
-//     receive plumbing of UDPBridge (resendMissingPackets / receive-side
-//     clamp in decodeResendRequest); this test pins the dispatch
-//     contract only, not that wire contract.
+//     strict-equality lookup on the canonical form — a request stamped
+//     with the untruncated form of an id already in the map must miss,
+//     not be silently routed via a prefix match at the dispatch seam.
+//     (The wire-canonicalization at insertion is what actually makes
+//     long configured ids route correctly in production; this test
+//     pins the dispatch seam.)
+//   - NewConnectionCanonicalizesLongId: a configured id ≥ 8 chars is
+//     truncated to the wire form at construction time, so a sender
+//     stamping the canonical form lands on the connection that owns
+//     sent_packets_ for that link.
 //   - DispatchMissWarnedIdsAreBounded: the bookkeeping table that
 //     dedups first-miss WARN logs has a hard cap (kDispatchMissWarnedCap)
 //     with FIFO eviction; a peer streaming distinct ids cannot grow
@@ -598,23 +602,20 @@ TEST_F(ResendFixture, DispatchDropsWithoutBroadcastUnknownConnectionId)
 // length normalization.
 //
 // Scope note: this test verifies the dispatch-side strict-match
-// invariant only. The full wire contract — "any id longer than 7
-// chars routes correctly in production" — is enforced by the
-// combination of (a) sender-side truncation in
-// UDPBridge::resendMissingPackets and (b) receive-side clamp in
-// UDPBridge::decodeResendRequest, both of which apply BEFORE
-// dispatchResendRequest is called. Neither has a dedicated unit
-// test because both are inside the private wire-decode plumbing of
-// UDPBridge; their integration is verified by the package's
-// end-to-end resend behavior in the field rather than at this seam.
-// A regression that re-introduces the pre-fix bug (sender stamps
-// the full untruncated id) would still route correctly today
-// because the receive-side clamp would normalize the id before
-// reaching dispatch. So a strict regression test for the wire
-// contract would require either a friend-declared test entry to
-// decodeResendRequest or a wire-format integration test that
-// constructs and dispatches a real packet — both out of scope for
-// this unit suite.
+// invariant only — dispatch must do strict equality on rr.connection_id,
+// not prefix-match. The wire contract — "any configured id ≥ 8 chars
+// routes correctly" — is enforced one layer up, by canonicalizing all
+// connections_ keys to the on-wire truncated form at every insertion
+// point (RemoteNode::newConnection and Connection::Connection both
+// run through packet.h's truncate_connection_id). With that
+// canonicalization in place, a sender's stamp (which is already
+// canonical because connection->id() returns the canonical form)
+// matches the canonical key in the receiver's connections_ map. The
+// receive-side clamp in UDPBridge::decodeResendRequest remains as a
+// defense against misbehaving peers that stamp the untruncated form.
+// The NewConnectionCanonicalizesLongId test below covers the new
+// contract directly: it constructs a connection with a > 7-char id
+// and asserts that dispatch routes a canonical-form stamp to it.
 TEST_F(ResendFixture, DispatchDoesNotFuzzyMatchConnectionId)
 {
   // The receiver's connection key is the truncated form (what would
@@ -653,7 +654,51 @@ TEST_F(ResendFixture, DispatchDoesNotFuzzyMatchConnectionId)
   }
 }
 
-// Routing case 5: bookkeeping cap. dispatchResendRequest tracks
+// Routing case 5: configured ids ≥ maximum_connection_id_size are
+// canonicalized to the on-wire truncated form at construction time, so
+// a sender stamping the canonical form (which is what
+// UDPBridge::resendMissingPackets does: connection->id() is already
+// canonical) finds the connection that holds sent_packets_ for that
+// link. This is the contract the round-8 self-review thought was held
+// by the wire-decode clamp alone; in production, BridgeInfo carries
+// the full configured id into the receiver's connections_ map under
+// the full key, and the wire-decode clamp would route the stamp to a
+// different (duplicate) Connection instance with empty sent_packets_.
+// Canonicalizing at insertion closes that gap.
+TEST_F(ResendFixture, NewConnectionCanonicalizesLongId)
+{
+  const std::string full_id = "starlink";   // 8 chars (>= max)
+  const std::string canonical_id = "starlin";
+
+  auto link = remote_->newConnection(full_id, "127.0.0.1", 9101);
+  ASSERT_NE(link, nullptr);
+
+  // Connection::id() reports the canonical form.
+  EXPECT_EQ(link->id(), canonical_id);
+
+  // Lookup is canonical-aware: callers passing either the full
+  // configured id or the on-wire truncated form land on the same
+  // connection. (newConnection should not have created a duplicate
+  // entry keyed on the full form.)
+  EXPECT_EQ(remote_->connection(canonical_id), link);
+  EXPECT_EQ(remote_->connection(full_id), link);
+
+  // The contract: a resend stamped with the canonical wire form (what
+  // a well-behaved sender's UDPBridge::resendMissingPackets produces)
+  // routes to the connection that owns sent_packets_ for that link.
+  ScopedFd sock;
+  ASSERT_GE(sock.get(), 0);
+  udp_bridge_interfaces::msg::ResendRequest rr;
+  rr.missing_packets = {1u};
+  rr.connection_id = canonical_id;
+  remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0));
+  EXPECT_EQ(link->resend_call_count_for_test(), 1u)
+    << "Canonical-form stamp must route to the connection created from "
+       "the long configured id. A miss here means the truncation "
+       "contract is back to one-sided.";
+}
+
+// Routing case 6: bookkeeping cap. dispatchResendRequest tracks
 // already-WARNed ids in a bounded FIFO to keep memory pressure
 // proportional to the configured connection-id space, not to whatever
 // the peer sends (a peer that streamed many distinct ids could

--- a/udp_bridge/test/test_remote_node_resend.cpp
+++ b/udp_bridge/test/test_remote_node_resend.cpp
@@ -23,10 +23,15 @@
 #include <cstdint>
 #include <vector>
 
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include <gtest/gtest.h>
 
 #include "rclcpp/rclcpp.hpp"
 
+#include "udp_bridge_interfaces/msg/resend_request.hpp"
+#include "udp_bridge/connection.h"
 #include "udp_bridge/remote_node.h"
 #include "udp_bridge/resend_constants.h"
 
@@ -443,6 +448,126 @@ TEST_F(ResendFixture, BurstLossAllGapsFlagTogetherAfterDebounce)
   EXPECT_EQ(rr.missing_packets[0], 2u);
   EXPECT_EQ(rr.missing_packets[1], 3u);
   EXPECT_EQ(rr.missing_packets[2], 4u);
+}
+
+// Issue #23: ResendRequests carry connection_id and dispatchResendRequest
+// routes the response to that one connection only — replacing the
+// previous broadcast across every active connection to the source remote,
+// which amplified resend volume 2-4x and pushed bytes into rx-dead paths
+// under the 2026-05-19 wifi-loss storm.
+//
+// The three tests below cover one matched-id case and two flavors of the
+// "stamped id is absent from the receiver's connections_" path:
+//   - StampedIdAbsent: receiver currently knows about a subset of the
+//     connection ids the sender knows about. Models the transient
+//     post-restart / pre-BridgeInfo-reconciliation window where the
+//     sender stamps for an id the receiver hasn't (re-)registered yet.
+//   - UnknownConnectionId: stamped id was never registered on the
+//     receiver at all. Models a config-mismatch coordinated-redeploy bug
+//     where the two bridges' connection-id strings don't agree.
+// Both no-op paths share dispatch's lookup-miss branch; the test split
+// documents the two operational scenarios an operator might be chasing
+// when the DEBUG log fires.
+
+namespace
+{
+
+// Open an unbound UDP socket for the dispatch tests. Connection::send
+// will hand this to sendto(); without a destination address the call
+// fails benignly with EDESTADDRREQ, which is fine — the assertion is
+// the per-connection counter, not the I/O. Caller closes via ScopedFd.
+class ScopedFd
+{
+public:
+  ScopedFd() : fd_(::socket(AF_INET, SOCK_DGRAM, 0)) {}
+  ~ScopedFd() { if(fd_ >= 0) ::close(fd_); }
+  ScopedFd(const ScopedFd&) = delete;
+  ScopedFd& operator=(const ScopedFd&) = delete;
+  int get() const { return fd_; }
+private:
+  int fd_;
+};
+
+}  // namespace
+
+// Routing case 1: a ResendRequest stamped for "wifi" reaches only the
+// wifi connection's resend_packets — not vpn's.
+TEST_F(ResendFixture, DispatchRoutesToStampedConnectionOnly)
+{
+  auto wifi = remote_->newConnection("wifi", "127.0.0.1", 9001);
+  auto vpn  = remote_->newConnection("vpn",  "127.0.0.1", 9002);
+  ASSERT_NE(wifi, nullptr);
+  ASSERT_NE(vpn,  nullptr);
+
+  // Seed one sent packet on each connection so resend_packets has
+  // something to look up. The lookup result doesn't matter for the
+  // assertion (we count calls, not sent bytes); seeding just exercises
+  // the production code path past its early-return.
+  wifi->record_sent_packet_for_test(1, t_at(1.0));
+  vpn->record_sent_packet_for_test(1, t_at(1.0));
+
+  udp_bridge_interfaces::msg::ResendRequest rr;
+  rr.missing_packets = {1u};
+  rr.connection_id = "wifi";
+
+  ScopedFd sock;
+  ASSERT_GE(sock.get(), 0);
+  remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0));
+
+  EXPECT_EQ(wifi->resend_call_count_for_test(), 1u)
+    << "Stamped-for connection should receive exactly one resend dispatch.";
+  EXPECT_EQ(vpn->resend_call_count_for_test(), 0u)
+    << "Non-stamped connection must not receive a resend — this is the "
+       "amplification bug issue #23 is fixing.";
+}
+
+// Routing case 2: stamped id is absent from the receiver's connections_
+// (subset state). Models the race window where the receiver hasn't
+// re-registered the connection yet but the sender already stamped for
+// it. Dispatch must no-op silently — must not fall back to broadcast
+// (that's the old behavior this issue removes).
+TEST_F(ResendFixture, DispatchSilentlyDropsWhenStampedIdAbsent)
+{
+  // Receiver knows only "vpn" right now; sender stamped for "wifi".
+  auto vpn = remote_->newConnection("vpn", "127.0.0.1", 9002);
+  ASSERT_NE(vpn, nullptr);
+  vpn->record_sent_packet_for_test(1, t_at(1.0));
+
+  udp_bridge_interfaces::msg::ResendRequest rr;
+  rr.missing_packets = {1u};
+  rr.connection_id = "wifi";
+
+  ScopedFd sock;
+  ASSERT_GE(sock.get(), 0);
+  remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0));
+
+  EXPECT_EQ(vpn->resend_call_count_for_test(), 0u)
+    << "Lookup miss must not fan out to the other live connection — "
+       "that would reintroduce the broadcast behavior issue #23 removes.";
+}
+
+// Routing case 3: stamped id was never registered (config mismatch
+// across coordinated redeploys). Same no-op path as case 2; differs in
+// known_ids log content (which is operator-facing, not asserted here).
+TEST_F(ResendFixture, DispatchSilentlyDropsUnknownConnectionId)
+{
+  auto wifi = remote_->newConnection("wifi", "127.0.0.1", 9001);
+  auto vpn  = remote_->newConnection("vpn",  "127.0.0.1", 9002);
+  ASSERT_NE(wifi, nullptr);
+  ASSERT_NE(vpn,  nullptr);
+  wifi->record_sent_packet_for_test(1, t_at(1.0));
+  vpn->record_sent_packet_for_test(1, t_at(1.0));
+
+  udp_bridge_interfaces::msg::ResendRequest rr;
+  rr.missing_packets = {1u};
+  rr.connection_id = "starlink";  // never registered on this RemoteNode
+
+  ScopedFd sock;
+  ASSERT_GE(sock.get(), 0);
+  remote_->dispatchResendRequest(rr, sock.get(), t_at(2.0));
+
+  EXPECT_EQ(wifi->resend_call_count_for_test(), 0u);
+  EXPECT_EQ(vpn->resend_call_count_for_test(),  0u);
 }
 
 int main(int argc, char** argv)

--- a/udp_bridge_interfaces/msg/ResendRequest.msg
+++ b/udp_bridge_interfaces/msg/ResendRequest.msg
@@ -1,2 +1,16 @@
 # Internal message used to ask to resend missing packets
 uint64[] missing_packets
+
+# Identifier of the connection the request was sent on. The receiver
+# uses this to route the resend response back via that single
+# connection instead of fanning out across every active path to the
+# remote (see issue #23 for the field motivation).
+#
+# Adding fields to this message changes the serialized wire layout.
+# Mixed-version sender/receiver interoperation is NOT guaranteed by
+# the schema alone — both endpoints must be redeployed together when
+# this message changes. The receiver wraps decode in a try/catch and
+# logs+drops on deserialization failure rather than terminating, so a
+# transient mismatch does not crash the bridge. Same contract as
+# MessageInternal.msg.
+string connection_id

--- a/udp_bridge_interfaces/msg/ResendRequest.msg
+++ b/udp_bridge_interfaces/msg/ResendRequest.msg
@@ -9,8 +9,12 @@ uint64[] missing_packets
 # Adding fields to this message changes the serialized wire layout.
 # Mixed-version sender/receiver interoperation is NOT guaranteed by
 # the schema alone — both endpoints must be redeployed together when
-# this message changes. The receiver wraps decode in a try/catch and
-# logs+drops on deserialization failure rather than terminating, so a
-# transient mismatch does not crash the bridge. Same contract as
-# MessageInternal.msg.
+# this message changes (same coordinated-redeploy contract as
+# MessageInternal.msg). To bound the failure mode, the receiver
+# (UDPBridge::decodeResendRequest) wraps the deserialize call in a
+# try/catch and logs+drops on deserialization failure rather than
+# letting the exception propagate to the executor and kill the bridge.
+# Note: this catch lives at the decodeResendRequest site specifically;
+# other decode* sites (notably decodeMessageInternal) do not yet have
+# the same guard — don't generalize this claim until they do.
 string connection_id

--- a/udp_bridge_interfaces/msg/ResendRequest.msg
+++ b/udp_bridge_interfaces/msg/ResendRequest.msg
@@ -10,11 +10,18 @@ uint64[] missing_packets
 # Mixed-version sender/receiver interoperation is NOT guaranteed by
 # the schema alone — both endpoints must be redeployed together when
 # this message changes (same coordinated-redeploy contract as
-# MessageInternal.msg). To bound the failure mode, the receiver
-# (UDPBridge::decodeResendRequest) wraps the deserialize call in a
-# try/catch and logs+drops on deserialization failure rather than
-# letting the exception propagate to the executor and kill the bridge.
-# Note: this catch lives at the decodeResendRequest site specifically;
-# other decode* sites (notably decodeMessageInternal) do not yet have
-# the same guard — don't generalize this claim until they do.
+# MessageInternal.msg). The receiver (UDPBridge::decodeResendRequest)
+# wraps the deserialize call in a try/catch primarily for diagnostic
+# clarity: a deserialize throw on a stale-schema buffer surfaces as a
+# specific WARN ("Failed to deserialize ResendRequest from <node>
+# (<host>:<port>)") instead of UDPBridge::decode's outer catch-all
+# emitting the generic "decoding error on packet of type N" ERROR.
+# Executor survival is already provided by that outer catch-all in
+# UDPBridge::decode (which wraps every decode* dispatch); the
+# site-specific catch is about diagnosability of the
+# coordinated-redeploy scenario, not survival.
+# Note: this site-specific catch lives at decodeResendRequest only;
+# other decode* sites (notably decodeMessageInternal) emit the more
+# generic outer-catch message — don't generalize this claim until
+# they have their own site-specific catches.
 string connection_id


### PR DESCRIPTION
Closes #23

# Plan: Restrict resend response to the connection the request arrived on

## Issue

https://github.com/rolker/udp_bridge/issues/23

## Context

`UDPBridge::decodeResendRequest` (`udp_bridge.cpp:695-711`) currently iterates
all connections to the source remote and calls `resend_packets` on each. A single
`ResendRequest` therefore fans out to every active path. Combined with
`resendMissingPackets` (`udp_bridge.cpp:965-983`) broadcasting the *request* to all
paths, the cost under both-paths-alive is 4× resends per missing packet. The
2026-05-19 bizzy field deployment exposed this: ~65 % of wifi outbound was
resends (~950 KB/s), much of it sent into a wifi link that was rx-dead at the
time.

Per-issue review (`#23` comment) and user decision (2026-05-20) settle three
design forks:

1. **Coordinated-redeploy backward-compat**, not graceful field-add. The
   `MessageInternal.msg` precedent in this same package explicitly states CDR
   mixed-version interop is not guaranteed; we mirror that caveat on
   `ResendRequest.msg` and drop the "broadcast fallback for empty
   `connection_id`" branch entirely (it would never trigger cleanly anyway).
2. **Bench harness (#18) is out of scope for this PR.** Unit test only; a
   follow-up comment on #18 captures suggested scenarios.
3. **Default-on, no config knob.** New behavior is a strict subset of old
   coverage, but the only observed edge case (rx-only on one path) is rare and
   recovered by give-up + the next regular send.

## Approach

1. **`ResendRequest.msg` — add `string connection_id`** with a comment matching
   the tone of `MessageInternal.msg`'s coordinated-redeploy caveat.
2. **`UDPBridge::resendMissingPackets` — stamp per connection (truncated).**
   Replace the single `send(rr, remote.first, true)` broadcast with a
   per-connection loop: build a fresh `ResendRequest` for each live connection,
   stamp `connection_id` **truncated to `maximum_connection_id_size - 1`**
   (the same limit `WrappedPacket` enforces on the on-wire char array at
   `wrapped_packet.cpp:31-32`), send through that connection only via a
   `RemoteConnectionsList` carrying that one id. The truncation is the
   load-bearing detail: the receiver's `connections_` map is keyed on the
   already-truncated id (populated from packet headers in
   `RemoteNode::unwrap`), so stamping the full string would cause silent
   resend-routing loss for any configured id ≥ 8 chars (`starlink`,
   `cellular`, …). Hold the existing snapshot-then-iterate pattern (the
   locking shape is unchanged).
3. **Move routing into `RemoteNode`.** Add
   `RemoteNode::dispatchResendRequest(const ResendRequest&, int socket, rclcpp::Time now)`
   that looks up `connection(rr.connection_id)` and calls `resend_packets` on
   exactly that connection. If the id is not in `connections_`, no-op and
   emit a log that names both the stamped id and the set of currently
   known connection ids. Use **WARN the first time** we see an unrecognized id
   on this RemoteNode (so a real config mismatch is diagnosable at default log
   levels) and **DEBUG on subsequent misses for the same id** (so legitimate
   CONNECT-cycle races don't spam). Bookkeeping is a `std::set<std::string>`
   on RemoteNode guarded by `state_mutex_` — never pruned, bounded by the
   configuration space of legitimate-then-removed ids. Keeps the routing
   logic on the class that owns the connection map and is already directly
   constructed in `test_remote_node_resend.cpp`'s fixture.
4. **`UDPBridge::decodeResendRequest` becomes a thin shim with try/catch.**
   Wrap `deserialize<ResendRequest>(message)` in a `try { … } catch(const
   std::exception&)` block that logs+drops on failure — makes good on the
   "logs+drops on deserialization failure" promise the new `ResendRequest.msg`
   comment makes. Then snapshot the matching `RemoteNode` under
   `remote_nodes_mutex_` and call `dispatchResendRequest` outside the lock
   (same pattern as today — network I/O outside `remote_nodes_mutex_`). The
   parallel gap in `decodeMessageInternal` (which `MessageInternal.msg` also
   wrongly promises is guarded) is pre-existing and gets its own follow-up
   issue rather than expanding scope here.
5. **Test seam: per-connection resend-call counter.** Add a
   `UDP_BRIDGE_BUILD_TESTING`-gated `resend_call_count_for_test()` accessor on
   `Connection`. `resend_packets` increments the counter at entry (before the
   network I/O). Mirrors the existing `record_sent_packet_for_test` /
   `sent_packet_count_for_test` pattern at `connection.h:102-127`.
6. **Unit tests.** Four new `TEST_F`s in `test_remote_node_resend.cpp`.
   Common setup: `RemoteNode` with `Connection`s constructed via
   `newConnection`; `ScopedFd` RAII helper opens a real UDP socket via
   `socket(AF_INET, SOCK_DGRAM, 0)` (kernel accepts the loopback datagram
   even with no listener — `Connection::resend_packets` increments the
   counter at function entry before any sendto, so I/O outcome doesn't
   affect the assertion). No `record_sent_packet_for_test` seeding —
   the test counter is bumped pre-lookup, so seeding wouldn't change
   anything and would be misleading scaffolding.
   - **Matched-id routing.** Two connections (`"wifi"`, `"vpn"`); stamp
     for `"wifi"`; assert wifi's counter is 1 and vpn's is 0.
   - **Stamped id absent (transient state).** Register only `"vpn"`;
     stamp for `"wifi"`. Models the post-restart / pre-BridgeInfo-
     reconciliation window where the receiver hasn't re-registered the
     connection yet. Assert vpn's counter stays at 0 (must not fall
     back to broadcast).
   - **Unknown id (config mismatch).** Register both `"wifi"` and
     `"vpn"`; stamp for `"iridium"` (an id this RemoteNode has never
     seen). Same lookup-miss code path as the absent-id case; differs
     in the `known_ids` payload of the WARN log, which documents the
     two operator scenarios. Assert both counters stay at 0.
   - **Truncated-id contract.** Register a connection keyed on the
     truncated form (`"starlin"`, what the receiver would have after
     packets from a configured-as-`"starlink"` connection arrive).
     Two-part assertion: stamp with `"starlin"` (the post-fix sender
     behavior) — counter goes to 1; stamp with `"starlink"` (the
     pre-fix bug) — counter stays at 1 (lookup misses). Documents the
     wire contract and catches any regression that reintroduces the
     full-id stamp.
7. **Follow-up comment on #18.** After PR opens, post a short note listing
   suggested bench scenarios: (a) verify per-connection routing under
   normal traffic, (b) verify no resends fan out to a path with rx loss,
   (c) measure outbound bytes/sec reduction vs the broadcast baseline.

## Files to Change

| File | Change |
|---|---|
| `udp_bridge_interfaces/msg/ResendRequest.msg` | Add `string connection_id` field + coordinated-redeploy comment block |
| `udp_bridge/src/udp_bridge.cpp` | Rewrite `resendMissingPackets` (per-connection stamp+send); rewrite `decodeResendRequest` as RemoteNode dispatch shim |
| `udp_bridge/include/udp_bridge/remote_node.h` | Declare `dispatchResendRequest(const ResendRequest&, int, rclcpp::Time)` |
| `udp_bridge/src/remote_node.cpp` | Implement `dispatchResendRequest` |
| `udp_bridge/include/udp_bridge/connection.h` | Add `resend_call_count_for_test()` under `UDP_BRIDGE_BUILD_TESTING`; counter member under same gate |
| `udp_bridge/src/connection.cpp` | Increment counter at entry of `resend_packets` (gated) |
| `udp_bridge/test/test_remote_node_resend.cpp` | Four new `TEST_F`s (matched-id routing; stamped-id-absent; unknown-id; truncated-id contract) + a `ScopedFd` RAII helper for the dispatch dummy socket |
| `udp_bridge/CMakeLists.txt` | Add `add_udp_bridge_gtest()` helper that wraps `ament_add_gtest` + `target_compile_definitions(UDP_BRIDGE_BUILD_TESTING)` + `target_link_libraries`. Extend the macro to every test target (previously only on two) — see Implementation Notes for the ODR rationale |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Human control and transparency | Behavior change is opt-out at deployment level (coordinated redeploy); resend volume drop is observable through existing `DataRates.*_bytes_per_second` per connection |
| A change includes its consequences | Wire-format change → `ResendRequest.msg` comment documents the redeploy contract; no out-of-package consumers (internal control plane); unit test lands with the change |
| Only what's needed | No config knob, no fallback branch; ~80 LOC plus test |
| Test what breaks | Unit test asserts routing on the exact decision the field storm exposed; counter seam keeps it deterministic |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 — Worktree isolation | Yes | Plan committed from worktree `feature/issue-23` |
| 0008 — ROS 2 official conventions | Yes | Additive trailing field on `ResendRequest.msg` is the conventional pattern; documenting the CDR coordinated-redeploy caveat (matching `MessageInternal.msg`'s existing comment) is the honest version of "ROS message defaults" |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `ResendRequest.msg` (interface) | Downstream consumers | Yes — verified: no external consumers; internal control-plane only |
| Resend fan-out behavior | Bench harness | Deferred: follow-up comment on #18, not blocking |
| `decodeResendRequest` routing | Tests covering the routing | Yes — two new `TEST_F`s |
| Connection method (`resend_packets`) instrumentation | Connection's other test helpers | No new accessor needed beyond the counter; matches existing seam pattern |

## Open Questions

None for implementation — the three design forks are settled. One operational
note: when this lands, bizzy and operator must be redeployed together. Capture
in the PR body so it's visible to whoever cuts the deployment.

## Estimated Scope

Single PR. ~80 LOC code + ~50 LOC test. Comparable to the resend-loop work in
PR #13.

## Implementation Notes

- **ODR pitfall surfaced in CMakeLists.** The plan called for a
  `UDP_BRIDGE_BUILD_TESTING`-gated counter on `Connection`. The existing
  test-only helpers (`record_sent_packet_for_test`,
  `sent_packet_count_for_test`) are method-only and don't change class
  layout; my counter, however, is a real data member (`std::size_t
  resend_call_count_for_test_`) and therefore changes `sizeof(Connection)`
  when the macro is defined. Before the CMakeLists change, only two test
  targets defined the macro — the rest (notably
  `test_connection_rate_limit`, which constructs `Connection` directly)
  compiled against a smaller layout while linking to a library compiled
  with the larger layout. That ODR mismatch reproduced as a clean
  segfault in `ConcurrentSendsStayUnderLimit`. The fix wraps every test
  target in `add_udp_bridge_gtest()` so they all carry the macro; the
  existing namespaced-macro comment already anticipated the downstream-
  consumer hazard but didn't extend the discipline to in-package tests.
  Documented in CMakeLists so a future agent adding another counter
  doesn't have to re-discover this.

- **Connection-id 8-char wire limit (round-2 fix).** The first
  implementation pass stamped `connection->id()` (the full configured
  string) into `ResendRequest.connection_id`. Review caught that the
  on-wire `SequencedPacketHeader` carries a fixed `char[8]` connection
  id (per `maximum_connection_id_size = 8`, originally added 2023-06-20
  when the bridge moved off UDP-return-address routing). The receiver's
  `connections_` map is keyed on the truncated id (populated from
  packet headers in `RemoteNode::unwrap`), so the full-string stamp
  would have caused silent resend-routing loss for any configured id
  ≥ 8 chars — and `"starlink"` is exactly 8. Fix: truncate the stamp
  to `maximum_connection_id_size - 1` in `resendMissingPackets`,
  mirroring what `WrappedPacket` already does at
  `wrapped_packet.cpp:31-32`. Round-2 also added the
  `DispatchHonorsTruncatedConnectionId` test as a regression guard.
  Not addressed here: raising the 8-byte limit (would require a
  wire-format change to every data packet header — separate issue).

- **try/catch on `decodeResendRequest` (round-2 fix).** The new
  `ResendRequest.msg` comment originally claimed the receiver wrapped
  decode in try/catch (mirroring `MessageInternal.msg`'s comment) —
  review caught that no such wrap actually existed at
  `decodeResendRequest`, *or* at `decodeMessageInternal`. Round-2 added
  the wrap at the `decodeResendRequest` site this PR introduces and
  tightened the message comment to be specific (not a systemic claim).
  The pre-existing `decodeMessageInternal` gap is left for a follow-up
  issue rather than expanding scope.

- **Dispatch-miss WARN once-per-id (round-2 fix).** Review surfaced
  that the original DEBUG-only log on dispatch lookup miss was too
  quiet for genuine coordinated-redeploy mismatches (operator chasing
  "resends stopped working" wouldn't see it at default log levels).
  Promoted to WARN on first miss per id (state bookkeeping in a small
  set on RemoteNode), DEBUG on subsequent — surfaces real config
  errors without spamming during legitimate CONNECT-cycle races.
